### PR TITLE
fix(ci): resolve systemic CI failures across dependabot PRs (#1481-#1490)

### DIFF
--- a/.github/workflows/security-and-terraform.yml
+++ b/.github/workflows/security-and-terraform.yml
@@ -57,7 +57,7 @@ jobs:
           for d in "${TF_DIRS[@]}"; do
             echo "\n=== Validating Terraform in $d ==="
             pushd "$d" >/dev/null
-            terraform init -backend=false -input=false -no-color
+            terraform init -backend=false -input=false -no-color -upgrade
             terraform validate -no-color
             popd >/dev/null
           done

--- a/.github/workflows/terraform-tests.yml
+++ b/.github/workflows/terraform-tests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache-dependency-path: tests/terratest/go.sum
 
       - name: Setup Terraform
@@ -96,7 +96,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache-dependency-path: tests/terratest/go.sum
 
       - name: Setup Terraform
@@ -163,7 +163,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache-dependency-path: tests/terratest/go.sum
 
       - name: Setup Terraform
@@ -226,7 +226,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache-dependency-path: tests/terratest/go.sum
 
       - name: Setup Terraform


### PR DESCRIPTION
## What this PR does
Resolves the systemic CI failures affecting all dependabot PRs #1481-#1490.

## Root cause
Two systemic issues in CI workflows:

1. **`validate-and-scan` fails on all PRs**: `terraform init` in `security-and-terraform.yml` does not use `-upgrade`. When dependabot bumps provider version constraints, `.terraform.lock.hcl` becomes stale and terraform refuses to proceed because the locked version no longer satisfies the new constraint. Example: hashicorp/aws locked at 6.51.0 but constraint now requires >= 6.52.0.

2. **`Terraform Validation Tests` + `Infrastructure Cost Estimation` fail on go_modules PRs**: `go-version: "1.24"` in `terraform-tests.yml` is too old for `tests/terratest/go.mod` which requires >= 1.25.8 after gRPC dependency upgrades. The `GOTOOLCHAIN=local` setting prevents auto-toolchain download.

## Which layer(s) are touched
- `.github/workflows/` — CI pipeline (2 files)

## Fixes
1. `security-and-terraform.yml:60` — add `-upgrade` to `terraform init`
2. `terraform-tests.yml` — bump `go-version` from `"1.24"` to `"1.25"` (4 jobs)

## Tests added or updated
- Validated `terraform init -upgrade` works locally in `infra/azure/`

## Linters passing locally
- ✅ pre-commit (YAML)

## Any judgment calls flagged for human review
- `-upgrade` in CI means validation uses latest providers satisfying constraints rather than reproducing exactly the locked versions. This is appropriate for CI validation but lock files should still be updated periodically for reproducibility.
- This PR fixes the same go-version issue already applied in PR #1466 (fix/critical-cves).

## Affected PRs resolved by this fix
- #1481 (pymdown-extensions)
- #1482 (gitpython)
- #1483 (azurerm 4.79.0) — closed
- #1484 (pytest-cov)
- #1485 (mkdocs)
- #1486 (hypothesis)
- #1487 (actions/cache)
- #1488 (go_modules group) — also fixes go-version issue
- #1489 (kubernetes provider)
- #1490 (azurerm 4.80.0)