### PR TITLE
fix(ci): repair reusable-lint.yml indentation and pin valid Trivy tag

### DIFF
--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -332,51 +332,51 @@ jobs:
   lint-summary:
     name: Lint Summary
     runs-on: ubuntu-latest
-  timeout-minutes: ${{ inputs.timeout-minutes }}
-  needs:
-    - detect-changes
-    - python-lint
-    - shell-lint
-    - yaml-lint
-    - typescript-lint
-    - go-lint
-  if: always()
-  outputs:
-    result: ${{ steps.outcome.outputs.result }}
-  steps:
-    - name: DORA job start
-      run: |
-        echo "job-start:$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-        echo "sha:${{ github.sha }}"
-        echo "workflow:${{ github.workflow }}"
-        echo "job:${{ github.job }}"
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    needs:
+      - detect-changes
+      - python-lint
+      - shell-lint
+      - yaml-lint
+      - typescript-lint
+      - go-lint
+    if: always()
+    outputs:
+      result: ${{ steps.outcome.outputs.result }}
+    steps:
+      - name: DORA job start
+        run: |
+          echo "job-start:$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "sha:${{ github.sha }}"
+          echo "workflow:${{ github.workflow }}"
+          echo "job:${{ github.job }}"
 
-    - name: Check all lint jobs
-      id: outcome
-      run: |
-        if [[ "${{ needs.python-lint.result }}" == "failure" ]] || \
-           [[ "${{ needs.shell-lint.result }}" == "failure" ]] || \
-           [[ "${{ needs.yaml-lint.result }}" == "failure" ]] || \
-           [[ "${{ needs.typescript-lint.result }}" == "failure" ]] || \
-           [[ "${{ needs.go-lint.result }}" == "failure" ]]; then
-          echo "result=fail" >> $GITHUB_OUTPUT
-          exit 1
-        fi
-        echo "result=pass" >> $GITHUB_OUTPUT
+      - name: Check all lint jobs
+        id: outcome
+        run: |
+          if [[ "${{ needs.python-lint.result }}" == "failure" ]] || \
+             [[ "${{ needs.shell-lint.result }}" == "failure" ]] || \
+             [[ "${{ needs.yaml-lint.result }}" == "failure" ]] || \
+             [[ "${{ needs.typescript-lint.result }}" == "failure" ]] || \
+             [[ "${{ needs.go-lint.result }}" == "failure" ]]; then
+            echo "result=fail" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+          echo "result=pass" >> $GITHUB_OUTPUT
 
-    - name: Generate summary
-      if: always()
-      run: |
-        echo "## Lint Results" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "| Language | Status |" >> $GITHUB_STEP_SUMMARY
-        echo "|----------|--------|" >> $GITHUB_STEP_SUMMARY
-        echo "| Python | ${{ needs.python-lint.result == 'skipped' && '⏭️ N/A' || (needs.python-lint.result == 'success' && '✅ Pass' || '❌ Fail') }} |" >> $GITHUB_STEP_SUMMARY
-        echo "| Shell | ${{ needs.shell-lint.result == 'skipped' && '⏭️ N/A' || (needs.shell-lint.result == 'success' && '✅ Pass' || '❌ Fail') }} |" >> $GITHUB_STEP_SUMMARY
-        echo "| YAML | ${{ needs.yaml-lint.result == 'skipped' && '⏭️ N/A' || (needs.yaml-lint.result == 'success' && '✅ Pass' || '❌ Fail') }} |" >> $GITHUB_STEP_SUMMARY
-        echo "| TypeScript | ${{ needs.typescript-lint.result == 'skipped' && '⏭️ N/A' || (needs.typescript-lint.result == 'success' && '✅ Pass' || '❌ Fail') }} |" >> $GITHUB_STEP_SUMMARY
-        echo "| Go | ${{ needs.go-lint.result == 'skipped' && '⏭️ N/A' || (needs.go-lint.result == 'success' && '✅ Pass' || '❌ Fail') }} |" >> $GITHUB_STEP_SUMMARY
+      - name: Generate summary
+        if: always()
+        run: |
+          echo "## Lint Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Language | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Python | ${{ needs.python-lint.result == 'skipped' && '⏭️ N/A' || (needs.python-lint.result == 'success' && '✅ Pass' || '❌ Fail') }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Shell | ${{ needs.shell-lint.result == 'skipped' && '⏭️ N/A' || (needs.shell-lint.result == 'success' && '✅ Pass' || '❌ Fail') }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| YAML | ${{ needs.yaml-lint.result == 'skipped' && '⏭️ N/A' || (needs.yaml-lint.result == 'success' && '✅ Pass' || '❌ Fail') }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| TypeScript | ${{ needs.typescript-lint.result == 'skipped' && '⏭️ N/A' || (needs.typescript-lint.result == 'success' && '✅ Pass' || '❌ Fail') }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Go | ${{ needs.go-lint.result == 'skipped' && '⏭️ N/A' || (needs.go-lint.result == 'success' && '✅ Pass' || '❌ Fail') }} |" >> $GITHUB_STEP_SUMMARY
 
-    - name: DORA job finish
-      if: always()
-      run: echo "job-finish:$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      - name: DORA job finish
+        if: always()
+        run: echo "job-finish:$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/.github/workflows/tracer-bullet-ci.yml
+++ b/.github/workflows/tracer-bullet-ci.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Install Trivy
         run: |
-          TRIVY_VERSION=0.70.0
+          TRIVY_VERSION=v0.70.0
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${TRIVY_VERSION}
 
       - name: Trivy scan


### PR DESCRIPTION
## Summary
- `reusable-lint.yml`: the `lint-summary` job's fields (`timeout-minutes`, `needs`, `if`, `outputs`, `steps`) were dedented to the same indentation level as the job key itself, turning them into sibling job entries instead of properties of `lint-summary`. GitHub Actions rejected the whole workflow file before running any job ("This run likely failed because of a workflow file issue").
- `tracer-bullet-ci.yml`: `TRIVY_VERSION=0.70.0` was missing the `v` prefix that `aquasecurity/trivy` release tags actually use, so the install script's GitHub release lookup failed with `unable to find '0.70.0'`.

Both were failing on `main` after PR #1517 merged (`Tracer Bullet CI/CD #25`, `.github/workflows/reusable-lint.yml #8`).

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` confirms `reusable-lint.yml` now parses into 7 well-formed job entries with `lint-summary` correctly nested
- [x] Local `pre-commit` YAML lint hook passes on both files
- [ ] CI green on this PR (Tracer Bullet CI/CD, reusable lint workflows)