### PR TITLE
fix(ci): grant actions:read permission for Main CI Guard reusable workflow

### DIFF
--- a/.github/workflows/main-ci-guard.yml
+++ b/.github/workflows/main-ci-guard.yml
@@ -9,6 +9,7 @@ permissions:
   contents: read
   checks: write
   pull-requests: write
+  actions: read
 
 jobs:
   dora-logging:


### PR DESCRIPTION
## Summary
- `main-ci-guard.yml` calls the external reusable workflow `paruff/ufawkespipe/.github/workflows/reusable-main-ci-guard.yml@v1.2.0`, whose `check-main-ci` job requests `actions: read` (needed to query another workflow's run status).
- The caller's `permissions:` block only granted `contents: read`, `checks: write`, `pull-requests: write`, so GitHub rejected the workflow file entirely at startup: "the nested job 'check-main-ci' is requesting 'actions: read', but is only allowed 'actions: none'."
- This broke every PR against `main` (surfaced most recently on dependabot PR #1510, "Main CI Guard" startup failure).

## Fix
Add `actions: read` to the caller's top-level `permissions:` block so it can grant the scope the reusable workflow's job requires.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` confirms valid YAML
- [x] Local pre-commit YAML lint hook passes
- [ ] CI green on this PR (Main CI Guard no longer startup-fails)