### PR TITLE
fix(ci): restore contents/actions permissions to main-ci-guard job

### DIFF
--- a/.github/workflows/main-ci-guard.yml
+++ b/.github/workflows/main-ci-guard.yml
@@ -31,6 +31,8 @@ jobs:
     with:
       workflow-id: code-quality.yml
     permissions:
+      contents: read
+      actions: read
       checks: write
       pull-requests: write
 


### PR DESCRIPTION
## Summary
- Job-level `permissions:` blocks override (not merge with) workflow-level permissions in GitHub Actions.
- The `main-ci-guard` job's block only listed `checks: write` / `pull-requests: write`, silently dropping `contents: read` and `actions: read` — causing the reusable workflow's `check-main-ci` job to fail with "requesting 'actions: read, contents: read', but is only allowed 'actions: none, contents: none'".
- Restores both permissions at the job level.

## Test plan
- [ ] `Main CI Guard` check passes on this PR
- [ ] `Pre-commit Validation` passes