### PR TITLE
fix(infra): update Azure resources for azurerm v5.0 breaking schema changes

### DIFF
--- a/infra/azure/backup.tf
+++ b/infra/azure/backup.tf
@@ -31,9 +31,6 @@ resource "azurerm_recovery_services_vault" "aks_backup" {
   resource_group_name = azurerm_resource_group.aks_rg.name
   sku                 = "Standard"
 
-  # Soft delete retention (7-90 days)
-  soft_delete_enabled = true
-
   tags = merge(var.tags, {
     component = "backup"
     purpose   = "persistent-volume-backup"

--- a/infra/azure/main.tf
+++ b/infra/azure/main.tf
@@ -123,6 +123,11 @@ resource "azurerm_kubernetes_cluster" "aks" {
     ]
   }
 
+  # Node pools are managed manually via azurerm_kubernetes_cluster_node_pool (no AKS Node Auto Provisioning)
+  node_provisioning_profile {
+    mode = "Manual"
+  }
+
   tags = var.tags
 }
 


### PR DESCRIPTION
## What
Fixes `terraform validate` failures in `infra/azure`, currently broken on `main` (and therefore on every open PR, including #1526).

## Root cause
`c0773a95` bumped the `azurerm` provider from 4.81.0 to 5.0.1 without updating the two resources whose schema changed in that major version:

- `azurerm_recovery_services_vault.aks_backup` — `soft_delete_enabled` was removed in v5.0 (soft delete is now always-on and non-configurable).
- `azurerm_kubernetes_cluster.aks` — `node_provisioning_profile` became a required block in v5.0.

## Change
- Removed the obsolete `soft_delete_enabled = true` line.
- Added `node_provisioning_profile { mode = "Manual" }`, matching the existing manual node-pool management (via the separate `azurerm_kubernetes_cluster_node_pool.user` resource) — no behavior change, just satisfies the new required schema.

## Layer(s) touched
`infra/` (Terraform, Azure only)

## Tests
- `terraform fmt -check`, `terraform init -backend=false`, `terraform validate` all pass locally for `infra/azure`.
- Full pre-commit suite passed locally (terraform fmt/validate/tflint/tfsec/docs).

## Judgment calls for review
- `mode = "Manual"` was chosen to preserve current behavior exactly (no AKS Node Auto Provisioning). Flagging for human review per AGENTS.md since this is an `infra/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)