### PR TITLE
fix(infra): tighten insecure SG/endpoint defaults in unused AWS modules

### DIFF
--- a/infra/terraform/modules/aws/eks/README.md
+++ b/infra/terraform/modules/aws/eks/README.md
@@ -32,7 +32,7 @@ module "eks" {
 
   endpoint_private_access = true
   endpoint_public_access  = true
-  api_server_authorized_ip_ranges = ["0.0.0.0/0"]
+  api_server_authorized_ip_ranges = ["203.0.113.10/32"]
 
   enable_ebs_csi_driver              = true
   enable_cluster_autoscaler          = true
@@ -73,6 +73,8 @@ module "eks" {
 | enable_cluster_autoscaler           | Enable Cluster Autoscaler IAM role | `bool`         | `true`                  |    no    |
 | enable_aws_load_balancer_controller | Enable AWS LB Controller IAM role  | `bool`         | `true`                  |    no    |
 | cluster_log_types                   | Control plane log types            | `list(string)` | `["api", "audit", ...]` |    no    |
+| api_server_authorized_ip_ranges     | Authorized API server CIDRs (empty = deny all) | `list(string)` | `[]`            |    no    |
+| egress_cidr_blocks                  | Egress CIDR blocks (defaults to VPC CIDR) | `list(string)` | `[]`            |    no    |
 | tags                                | Tags to apply to resources         | `map(string)`  | `{}`                    |    no    |
 
 ## Outputs
@@ -219,7 +221,7 @@ See the [examples directory](../examples/) for complete usage examples:
 | <a name="input_cluster_name"></a> [cluster_name](#input_cluster_name)                                                                      | Name of the EKS cluster                                            | `string`                                                                                     | n/a                                                                                                           |   yes    |
 | <a name="input_private_subnet_ids"></a> [private_subnet_ids](#input_private_subnet_ids)                                                    | List of private subnet IDs for EKS nodes                           | `list(string)`                                                                               | n/a                                                                                                           |   yes    |
 | <a name="input_vpc_id"></a> [vpc_id](#input_vpc_id)                                                                                        | ID of the VPC where EKS cluster will be created                    | `string`                                                                                     | n/a                                                                                                           |   yes    |
-| <a name="input_api_server_authorized_ip_ranges"></a> [api_server_authorized_ip_ranges](#input_api_server_authorized_ip_ranges)             | Authorized IP ranges for API server access (empty list allows all) | `list(string)`                                                                               | <pre>[<br/> "0.0.0.0/0"<br/>]</pre>                                                                           |    no    |
+| <a name="input_api_server_authorized_ip_ranges"></a> [api_server_authorized_ip_ranges](#input_api_server_authorized_ip_ranges)             | Authorized IP ranges for API server access (empty list denies all public access) | `list(string)`                                                                               | `[]`                                                                           |    no    |
 | <a name="input_cluster_log_retention_days"></a> [cluster_log_retention_days](#input_cluster_log_retention_days)                            | Number of days to retain cluster logs in CloudWatch                | `number`                                                                                     | `7`                                                                                                           |    no    |
 | <a name="input_cluster_log_types"></a> [cluster_log_types](#input_cluster_log_types)                                                       | List of control plane logging types to enable                      | `list(string)`                                                                               | <pre>[<br/> "api",<br/> "audit",<br/> "authenticator",<br/> "controllerManager",<br/> "scheduler"<br/>]</pre> |    no    |
 | <a name="input_coredns_addon_version"></a> [coredns_addon_version](#input_coredns_addon_version)                                           | Version of the CoreDNS addon                                       | `string`                                                                                     | `null`                                                                                                        |    no    |
@@ -321,11 +323,12 @@ See the [examples directory](../examples/) for complete usage examples:
 | <a name="input_cluster_name"></a> [cluster_name](#input_cluster_name) | Name of the EKS cluster | `string` | n/a | yes |
 | <a name="input_private_subnet_ids"></a> [private_subnet_ids](#input_private_subnet_ids) | List of private subnet IDs for EKS nodes | `list(string)` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc_id](#input_vpc_id) | ID of the VPC where EKS cluster will be created | `string` | n/a | yes |
-| <a name="input_api_server_authorized_ip_ranges"></a> [api_server_authorized_ip_ranges](#input_api_server_authorized_ip_ranges) | Authorized IP ranges for API server access (empty list allows all) | `list(string)` | <pre>[<br/>  "0.0.0.0/0"<br/>]</pre> | no |
+| <a name="input_api_server_authorized_ip_ranges"></a> [api_server_authorized_ip_ranges](#input_api_server_authorized_ip_ranges) | Authorized IP ranges for API server access (empty list denies all public access) | `list(string)` | `[]` | no |
 | <a name="input_cluster_log_retention_days"></a> [cluster_log_retention_days](#input_cluster_log_retention_days) | Number of days to retain cluster logs in CloudWatch | `number` | `7` | no |
 | <a name="input_cluster_log_types"></a> [cluster_log_types](#input_cluster_log_types) | List of control plane logging types to enable | `list(string)` | <pre>[<br/>  "api",<br/>  "audit",<br/>  "authenticator",<br/>  "controllerManager",<br/>  "scheduler"<br/>]</pre> | no |
 | <a name="input_coredns_addon_version"></a> [coredns_addon_version](#input_coredns_addon_version) | Version of the CoreDNS addon | `string` | `null` | no |
 | <a name="input_ebs_csi_driver_addon_version"></a> [ebs_csi_driver_addon_version](#input_ebs_csi_driver_addon_version) | Version of the EBS CSI driver addon | `string` | `null` | no |
+| <a name="input_egress_cidr_blocks"></a> [egress_cidr_blocks](#input_egress_cidr_blocks) | List of CIDR blocks allowed for outbound traffic (defaults to the VPC CIDR when empty) | `list(string)` | `[]` | no |
 | <a name="input_enable_aws_load_balancer_controller"></a> [enable_aws_load_balancer_controller](#input_enable_aws_load_balancer_controller) | Enable IAM role for AWS Load Balancer Controller | `bool` | `true` | no |
 | <a name="input_enable_cluster_autoscaler"></a> [enable_cluster_autoscaler](#input_enable_cluster_autoscaler) | Enable IAM role for Cluster Autoscaler | `bool` | `true` | no |
 | <a name="input_enable_ebs_csi_driver"></a> [enable_ebs_csi_driver](#input_enable_ebs_csi_driver) | Enable EBS CSI driver addon | `bool` | `true` | no |

--- a/infra/terraform/modules/aws/eks/main.tf
+++ b/infra/terraform/modules/aws/eks/main.tf
@@ -69,6 +69,11 @@ resource "aws_iam_role_policy_attachment" "cluster_amazon_eks_vpc_resource_contr
   role       = aws_iam_role.cluster.name
 }
 
+# Look up VPC CIDR so egress defaults to the VPC instead of 0.0.0.0/0
+data "aws_vpc" "this" {
+  id = var.vpc_id
+}
+
 # EKS Cluster Security Group
 resource "aws_security_group" "cluster" {
   name        = "${var.cluster_name}-cluster-sg"
@@ -76,11 +81,11 @@ resource "aws_security_group" "cluster" {
   vpc_id      = var.vpc_id
 
   egress {
-    description = "Allow all outbound traffic"
+    description = "Allow outbound to VPC CIDR by default (override via egress_cidr_blocks)"
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = length(var.egress_cidr_blocks) > 0 ? var.egress_cidr_blocks : [data.aws_vpc.this.cidr_block]
   }
 
   tags = merge(

--- a/infra/terraform/modules/aws/eks/variables.tf
+++ b/infra/terraform/modules/aws/eks/variables.tf
@@ -80,9 +80,9 @@ variable "endpoint_public_access" {
 }
 
 variable "api_server_authorized_ip_ranges" {
-  description = "Authorized IP ranges for API server access (empty list allows all)"
+  description = "Authorized IP ranges for API server access (empty list denies all public access)"
   type        = list(string)
-  default     = ["0.0.0.0/0"]
+  default     = []
 
   validation {
     condition = alltrue([
@@ -90,6 +90,25 @@ variable "api_server_authorized_ip_ranges" {
       can(cidrhost(cidr, 0))
     ])
     error_message = "All IP ranges must be valid CIDR blocks."
+  }
+
+  validation {
+    condition     = alltrue([for cidr in var.api_server_authorized_ip_ranges : cidr != "0.0.0.0/0"])
+    error_message = "0.0.0.0/0 is not allowed; specify explicit authorized IP ranges."
+  }
+}
+
+variable "egress_cidr_blocks" {
+  description = "List of CIDR blocks allowed for outbound traffic (defaults to the VPC CIDR when empty)"
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for cidr in var.egress_cidr_blocks :
+      can(cidrhost(cidr, 0))
+    ])
+    error_message = "All egress CIDR blocks must be valid."
   }
 }
 

--- a/infra/terraform/modules/aws/rds/README.md
+++ b/infra/terraform/modules/aws/rds/README.md
@@ -82,6 +82,7 @@ module "rds" {
 | monitoring_interval          | Enhanced monitoring interval             | `number`       | `0`             |    no    |
 | allowed_security_group_ids   | Allowed security groups                  | `list(string)` | `[]`            |    no    |
 | allowed_cidr_blocks          | Allowed CIDR blocks                      | `list(string)` | `[]`            |    no    |
+| egress_cidr_blocks           | Egress CIDR blocks (defaults to VPC CIDR) | `list(string)` | `[]`            |    no    |
 | tags                         | Tags to apply to resources               | `map(string)`  | `{}`            |    no    |
 
 ## Outputs
@@ -342,6 +343,7 @@ See the [examples directory](../examples/) for complete usage examples:
 | <a name="input_database_connections_threshold"></a> [database_connections_threshold](#input_database_connections_threshold) | Database connections threshold for CloudWatch alarm | `number` | `100` | no |
 | <a name="input_database_name"></a> [database_name](#input_database_name) | Name of the default database to create | `string` | `null` | no |
 | <a name="input_deletion_protection"></a> [deletion_protection](#input_deletion_protection) | Enable deletion protection | `bool` | `true` | no |
+| <a name="input_egress_cidr_blocks"></a> [egress_cidr_blocks](#input_egress_cidr_blocks) | List of CIDR blocks allowed for outbound traffic (defaults to the VPC CIDR when empty) | `list(string)` | `[]` | no |
 | <a name="input_enabled_cloudwatch_logs_exports"></a> [enabled_cloudwatch_logs_exports](#input_enabled_cloudwatch_logs_exports) | List of log types to export to CloudWatch | `list(string)` | `[]` | no |
 | <a name="input_free_storage_space_threshold"></a> [free_storage_space_threshold](#input_free_storage_space_threshold) | Free storage space threshold in bytes for CloudWatch alarm | `number` | `5000000000` | no |
 | <a name="input_instance_class"></a> [instance_class](#input_instance_class) | The instance class to use | `string` | `"db.t3.micro"` | no |

--- a/infra/terraform/modules/aws/rds/main.tf
+++ b/infra/terraform/modules/aws/rds/main.tf
@@ -69,6 +69,11 @@ resource "aws_db_parameter_group" "main" {
   )
 }
 
+# Look up VPC CIDR so egress defaults to the VPC instead of 0.0.0.0/0
+data "aws_vpc" "this" {
+  id = var.vpc_id
+}
+
 # Security Group
 resource "aws_security_group" "rds" {
   name        = "${var.identifier}-rds-sg"
@@ -88,11 +93,11 @@ resource "aws_security_group" "rds" {
   }
 
   egress {
-    description = "Allow all outbound"
+    description = "Allow outbound to VPC CIDR by default (override via egress_cidr_blocks)"
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = length(var.egress_cidr_blocks) > 0 ? var.egress_cidr_blocks : [data.aws_vpc.this.cidr_block]
   }
 
   tags = merge(

--- a/infra/terraform/modules/aws/rds/variables.tf
+++ b/infra/terraform/modules/aws/rds/variables.tf
@@ -303,6 +303,20 @@ variable "allowed_cidr_blocks" {
   }
 }
 
+variable "egress_cidr_blocks" {
+  description = "List of CIDR blocks allowed for outbound traffic (defaults to the VPC CIDR when empty)"
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for cidr in var.egress_cidr_blocks :
+      can(cidrhost(cidr, 0))
+    ])
+    error_message = "All egress CIDR blocks must be valid."
+  }
+}
+
 variable "create_cloudwatch_alarms" {
   description = "Create CloudWatch alarms for monitoring"
   type        = bool

--- a/reports/build-report-1534.md
+++ b/reports/build-report-1534.md
@@ -1,0 +1,95 @@
+# Build Report — security: fix insecure security-group/endpoint defaults in unused AWS library modules (#1534)
+
+**Status:** COMPLETE
+
+---
+
+## Context
+
+GitHub issue #1534 (P1, `type-security`, `terraform`): the unused AWS library modules
+`infra/terraform/modules/aws/{rds,eks}` hardcode `0.0.0.0/0` on security-group egress
+and on the EKS API-server authorized IP ranges default, which Trivy flagged as
+unrestricted egress / open CIDR public access (#459, #458, #457). Zero live callers
+confirmed — only README usage examples reference the modules, and `examples/` contains
+only the `vpc` example (unaffected).
+
+## Design decision (judgment call flagged for human review)
+
+To scope egress to the VPC CIDR **without** adding a new required input, I used a
+`data "aws_vpc"` lookup on the existing `vpc_id` (the same pattern the upstream
+`terraform-aws-modules/rds` uses) plus an `egress_cidr_blocks` override variable
+(default `[]` → falls back to the looked-up VPC CIDR). This satisfies the issue's
+"real default + override var" without forcing future callers to pass a new `vpc_cidr`
+variable. The EKS public-endpoint model (`endpoint_public_access` /
+`public_access_cidrs`) was **not** touched — the issue explicitly scopes that out as a
+separate issue.
+
+## Tasks Completed
+
+| Task                       | Title                                                                  | Files | Status |
+| -------------------------- | ---------------------------------------------------------------------- | ----- | ------ |
+| RDS egress default         | Replace `0.0.0.0/0` egress with VPC-CIDR-scoped default + override var | 2     | DONE   |
+| EKS egress default         | Replace `0.0.0.0/0` egress with VPC-CIDR-scoped default + override var | 2     | DONE   |
+| EKS API ranges default     | `api_server_authorized_ip_ranges` default `[]` + wildcard validation   | 1     | DONE   |
+| README examples            | Update usage examples + terraform-docs tables                          | 2     | DONE   |
+
+## Changes
+
+### `infra/terraform/modules/aws/rds/main.tf`
+
+- Added `data "aws_vpc" "this" { id = var.vpc_id }`
+- Egress: `cidr_blocks = length(var.egress_cidr_blocks) > 0 ? var.egress_cidr_blocks : [data.aws_vpc.this.cidr_block]`
+
+### `infra/terraform/modules/aws/rds/variables.tf`
+
+- Added `egress_cidr_blocks` (list(string), default `[]`, CIDR-validated)
+
+### `infra/terraform/modules/aws/eks/main.tf`
+
+- Added `data "aws_vpc" "this" { id = var.vpc_id }`
+- Egress: same VPC-CIDR-scoped default pattern
+
+### `infra/terraform/modules/aws/eks/variables.tf`
+
+- `api_server_authorized_ip_ranges`: default `["0.0.0.0/0"]` → `[]`; description updated;
+  added validation block rejecting `0.0.0.0/0`
+- Added `egress_cidr_blocks` (same as RDS)
+
+### READMEs (`rds`, `eks`)
+
+- Usage example: `api_server_authorized_ip_ranges = ["203.0.113.10/32"]` (documentation
+  IP, no longer the wildcard)
+- Handwritten Inputs tables + terraform-docs-generated tables updated
+
+## Validation Results
+
+| Check                       | Status | Notes                                                                  |
+| --------------------------- | ------ | ---------------------------------------------------------------------- |
+| `terraform fmt -check`      | PASS   | Recursive on both module dirs                                          |
+| `terraform validate`        | PASS   | Both modules (validated in scratch copies; local `.terraform` cache had a stale symlink, unrelated to config) |
+| `tflint`                    | PASS   | 0 issues, both modules                                                 |
+| `tfsec`                     | PASS   | SG ingress/egress wildcard CRITICALs eliminated; remaining findings pre-existing and out of scope (endpoint model, secret encryption, cluster-autoscaler IAM wildcard, log-group CMK — issue explicitly excludes them) |
+| `terraform-docs`            | PASS   | Both READMEs regenerated                                              |
+| Examples unaffected         | PASS   | `examples/` contains only `vpc`; no RDS/EKS snapshots to break         |
+| No live callers             | PASS   | Grep confirms only README references; zero TF callers                 |
+
+## Artifacts Produced
+
+- [x] Source changes in `infra/terraform/modules/aws/rds/{main,variables}.tf`
+- [x] Source changes in `infra/terraform/modules/aws/eks/{main,variables}.tf`
+- [x] README updates (usage + docs tables) for both modules
+
+## Blockers
+
+None.
+
+## Notes / Pre-existing issues (not fixed, out of scope)
+
+- EKS README has **two** `BEGIN_TF_DOCS` blocks (duplicate; the first was already
+  stale before this change — provider versions `6.27.0` vs `6.57.1`). terraform-docs
+  only refreshes the last block; I manually corrected the stale `0.0.0.0/0` value in
+  the first block but did not remove the duplication.
+- `data "aws_vpc"` requires `ec2:DescribeVpcs` on the caller's IAM role; already
+  required to resolve `vpc_id`, so no new permission burden.
+- 6 files touched (just over the 5-file ask-before threshold) — all within the
+  explicit file list in the issue body, flagged here for the record.


### PR DESCRIPTION
## What this PR does

Tightens insecure security-group/endpoint defaults in the unused AWS library modules (`infra/terraform/modules/aws/{rds,eks}`), closing Trivy alerts #459, #458, #457 (issue #1534).

## Layer touched

- **infra** — Terraform modules `aws/rds` and `aws/eks` (main.tf, variables.tf, READMEs)

## Changes

1. **Egress default (rds + eks)**: replaced hardcoded `cidr_blocks = ["0.0.0.0/0"]` on all-protocol egress with a VPC-CIDR-scoped default via `data "aws_vpc"` lookup on the existing `vpc_id`, plus an `egress_cidr_blocks` override variable (default `[]` → falls back to VPC CIDR).
2. **EKS API ranges default**: `api_server_authorized_ip_ranges` default changed from `["0.0.0.0/0"]` to `[]`, with a validation block rejecting the wildcard. Empty list now denies all public access; the SG ingress rule is not created.

## Tests / validation

- `terraform fmt -check` — PASS
- `terraform validate` — PASS (both modules; local pre-commit `terraform_validate` was blocked by a pre-existing stale `.terraform` provider symlink cache, unrelated to config — cleaned and re-ran)
- `tflint` — PASS (0 issues)
- `tfsec` — PASS; SG ingress/egress wildcard CRITICALs eliminated. Remaining findings (public endpoint model, secret encryption, cluster-autoscaler IAM wildcard, log-group CMK) are pre-existing and explicitly out of scope per the issue.
- `terraform-docs` — regenerated both READMEs
- Zero live callers confirmed — only README usage examples reference these modules; `examples/` contains only `vpc` (unaffected)

## Judgment calls flagged for human review

- **Egress design**: used `data "aws_vpc"` on existing `vpc_id` + `egress_cidr_blocks` override instead of adding a required `vpc_cidr` input (zero new required vars for future callers). Requires `ec2:DescribeVpcs`, already needed to resolve `vpc_id`.
- **6 files touched** (just over the 5-file threshold) — all in the issue's explicit file list.
- **Pre-existing quirk**: EKS README has duplicate `BEGIN_TF_DOCS` blocks (first already stale before this change); corrected the stale `0.0.0.0/0` value but left the duplication.

Full details in `reports/build-report-1534.md`.