### PR TITLE
fix(infra): remove wildcard source_address_prefix from azure/vnet example

### DIFF
--- a/infra/terraform/modules/azure/examples/vnet/main.tf
+++ b/infra/terraform/modules/azure/examples/vnet/main.tf
@@ -76,7 +76,7 @@ module "vnet" {
           protocol                   = "Tcp"
           source_port_range          = "*"
           destination_port_range     = "80"
-          source_address_prefix      = "*"
+          source_address_prefix      = "203.0.113.0/24" # Replace with your IP range
           destination_address_prefix = "*"
         }
         allow_https = {
@@ -86,7 +86,7 @@ module "vnet" {
           protocol                   = "Tcp"
           source_port_range          = "*"
           destination_port_range     = "443"
-          source_address_prefix      = "*"
+          source_address_prefix      = "203.0.113.0/24" # Replace with your IP range
           destination_address_prefix = "*"
         }
         allow_ssh = {


### PR DESCRIPTION
## What this PR does

Removes the `"*"` wildcard `source_address_prefix` from the azure/vnet example fixture, closing Trivy alerts #497 and #496 (issue #1535).

## Layer touched

- **infra** — Terraform example fixture `infra/terraform/modules/azure/examples/vnet/main.tf` (1 file, 2 lines)

## Changes

- `allow_http` and `allow_https` ingress rules: `source_address_prefix = "*"` → `"203.0.113.0/24"` (RFC 5737 doc range) with the same "Replace with your IP range" comment the existing `allow_ssh` rule uses.
- The reusable module (`azure/vnet`) is unchanged — it already takes `source_address_prefix` as a variable; only the fixture hardcoded the wildcard.

## Tests / validation

- `terraform fmt -check` — PASS
- `terraform validate` — PASS (example dir)
- `TestAzureVNetExampleValidation` (Terratest) — **PASS** (4.46s), exactly the verification named in the issue
- No `source_address_prefix = "*"` remains anywhere in `infra/terraform/modules/azure/`
- tfsec: example fixture now clean. Remaining findings are in the **module** (`azure/vnet/main.tf`) and are pre-existing — tfsec flags the doc-range CIDR as "public" ingress, same as the SSH rule did before this change; the Trivy alerts specifically target the wildcard, which is gone.

## Judgment calls flagged for human review

- Chose `203.0.113.0/24` to match the fixture's existing scoped-CIDR pattern (SSH rule) rather than a private RFC 1918 range, keeping the public-subnet demo meaningful. A real deployment must replace it with an actual operator IP range.

Full details in the commit message.