### PR TITLE
fix(test): add securityContext to azure-storage-test fixture pods

### DIFF
--- a/tests/integration/azure-storage-test.yaml
+++ b/tests/integration/azure-storage-test.yaml
@@ -118,6 +118,16 @@ spec:
       volumeMounts:
         - name: data
           mountPath: /data
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: false
+        capabilities:
+          drop:
+            - ALL
+  securityContext:
+    fsGroup: 1000
   volumes:
     - name: data
       persistentVolumeClaim:
@@ -154,6 +164,16 @@ spec:
       volumeMounts:
         - name: data
           mountPath: /data
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: false
+        capabilities:
+          drop:
+            - ALL
+  securityContext:
+    fsGroup: 1000
   volumes:
     - name: data
       persistentVolumeClaim:
@@ -187,6 +207,14 @@ spec:
       volumeMounts:
         - name: data
           mountPath: /data
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: false
+        capabilities:
+          drop:
+            - ALL
   volumes:
     - name: data
       persistentVolumeClaim:
@@ -224,6 +252,14 @@ spec:
       volumeMounts:
         - name: data
           mountPath: /data
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: false
+        capabilities:
+          drop:
+            - ALL
   volumes:
     - name: data
       persistentVolumeClaim:
@@ -265,6 +301,14 @@ spec:
       volumeMounts:
         - name: data
           mountPath: /data
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
   volumes:
     - name: data
       persistentVolumeClaim:


### PR DESCRIPTION
## What this PR does

Adds a securityContext to the 5 test-fixture pods in `tests/integration/azure-storage-test.yaml`, closing Trivy alerts #1649–#1642 (issue #1536, "Default security context configured").

## Layer touched

- **tests** — `tests/integration/azure-storage-test.yaml` (1 file, +44 lines)

## Changes (per the issue's fix pattern, matching `platform/observability/*/*-config.yaml`)

Each container gets:
```yaml
securityContext:
  runAsNonRoot: true
  runAsUser: 1000
  allowPrivilegeEscalation: false
  readOnlyRootFilesystem: false   # true for the reader pod
  capabilities:
    drop: ["ALL"]
```

- 4 writer pods: `readOnlyRootFilesystem: false` (they write to `/data`)
- 1 reader pod: `readOnlyRootFilesystem: true`
- Pod-level `fsGroup: 1000` on the two **disk-writer** pods only: Azure Disk volumes are root-owned with no fsGroup in the storage classes, so uid 1000 needs fsGroup to write. Azure Files is mounted `dir_mode=0777` and the reader is read-only, so they don't need it.

## Tests / validation

- `kubeconform -strict` — 11 Valid, 0 Invalid (1 "error" is the pre-existing missing schema for `VolumeSnapshot` CRD, not a validation failure)
- `kubectl apply --dry-run=server` not possible (no live cluster — k3d context exists but is down)
- Trivy `--scanners misconfig`: the 8 "Default security context configured" alerts are resolved. Note: local trivy 0.72.0 still reports KSV-0118 on the 3 pods with container-level-only context — this is a **known trivy bug** (aquasecurity/trivy#9329, fixed upstream; CI runs latest trivy via `n-action@master`). Verified the same false positive fires on the repo's own `xray-daemon-daemonset.yaml` (also container-level-only).
- Pre-commit hooks: PASS (kubeval/kubeconform, yamllint, etc.)

## Judgment calls flagged for human review

1. Added `runAsUser: 1000` which the issue's snippet omitted — required because busybox runs as root; `runAsNonRoot: true` alone makes the kubelet refuse to start the pods. Matches the repo's observability pattern.
2. Added `fsGroup: 1000` to disk-writer pods (not in the issue) — required so uid 1000 can actually write to root-owned Azure Disk volumes. File-writer and reader pods deliberately omit it (0777 mount / read-only).

Bonus: this also resolves the latent Kyverno `require-run-as-non-root` admission failure the issue noted for the `storage-test` namespace.

Full details in the commit message.