### PR TITLE
chore(ci): bump pinned tool versions to latest stable (2026-08)

### DIFF
--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: "3.13"
         cache: "pip"

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -172,7 +172,7 @@ jobs:
 
       - name: Coverage comment on PR
         if: github.event_name == 'pull_request'
-        uses: py-cov-action/python-coverage-comment-action@v3
+        uses: py-cov-action/python-coverage-comment-action@5d8df5979747514c914e1c5a12335a7cf9a2745f # v4.1
         with:
           GITHUB_TOKEN: ${{ github.token }}
           MINIMUM_GREEN: 80

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -219,7 +219,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: 1.9.5
+          terraform_version: 1.15.8
 
       - name: Cache Terraform providers
         uses: actions/cache@v6
@@ -322,7 +322,7 @@ jobs:
 
       - name: Install kustomize
         run: |
-          VERSION="v5.3.0"
+          VERSION="v5.8.1"
           wget -q -O kustomize.tar.gz "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${VERSION}/kustomize_${VERSION}_linux_amd64.tar.gz"
           tar -xzf kustomize.tar.gz
           sudo mv kustomize /usr/local/bin/

--- a/.github/workflows/reusable-security-scanning.yml
+++ b/.github/workflows/reusable-security-scanning.yml
@@ -48,18 +48,18 @@ jobs:
           echo "job:${{ github.job }}"
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Run secret scanning
         if: inputs.scan-type == 'all' || inputs.scan-type == 'secrets'
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_ENABLE_SUMMARY: true
 
       - name: Run Trivy vulnerability scanner
         if: inputs.scan-type == 'all' || inputs.scan-type == 'vulnerabilities'
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: "fs"
           scan-ref: ${{ inputs.scan-path }}

--- a/.github/workflows/security-and-terraform.yml
+++ b/.github/workflows/security-and-terraform.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: 1.9.5
+          terraform_version: 1.15.8
 
       # Cache Terraform providers (global plugin cache only — avoids filling disk with per-module .terraform/)
       - name: Cache Terraform providers

--- a/.github/workflows/terraform-tests.yml
+++ b/.github/workflows/terraform-tests.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: 1.9.5
+          terraform_version: 1.15.8
           terraform_wrapper: false
 
       - name: Download Go dependencies
@@ -102,7 +102,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: 1.9.5
+          terraform_version: 1.15.8
           terraform_wrapper: false
 
       - name: Setup Infracost
@@ -169,7 +169,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: 1.9.5
+          terraform_version: 1.15.8
           terraform_wrapper: false
 
       - name: Azure Login
@@ -232,7 +232,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: 1.9.5
+          terraform_version: 1.15.8
           terraform_wrapper: false
 
       - name: Azure Login

--- a/.github/workflows/tracer-bullet-ci.yml
+++ b/.github/workflows/tracer-bullet-ci.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Install Trivy
         run: |
-          TRIVY_VERSION=v0.70.0
+          TRIVY_VERSION=v0.73.0
           curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${TRIVY_VERSION}
 
       - name: Trivy scan

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -121,7 +121,7 @@ repos:
   # Python Code Quality (ruff format + lint replaces black + flake8)
   # ============================================================================
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.1
+    rev: v0.16.2
     hooks:
       - id: ruff
         name: Lint Python with Ruff


### PR DESCRIPTION
## What it does
Bumps all pinned CI/pre-commit tool versions to latest stable as of 2026-08-08. Unblocks future trivy scanning and closes a security finding.

## Layers touched
- `.github/workflows/` (CI) — 6 workflow files + 1 composite action
- `.pre-commit-config.yaml` (pre-commit hooks)

## Changes
| Tool | From | To | Notes |
|---|---|---|---|
| terraform | 1.9.5 | 1.15.8 | 6 call sites (pre-commit, security-and-terraform, terraform-tests ×4). Local already on 1.15.8. |
| kustomize | v5.3.0 | v5.8.1 | pre-commit.yml |
| trivy-action | @master | v0.36.0 (SHA) | **Security fix**: unpinned master violated our own pinning rule; CVE-2026-33634 affected trivy-action ≤0.34.2 |
| gitleaks-action | v2 | v3 | reusable-security-scanning.yml |
| checkout | v6 | v7 | reusable-security-scanning.yml |
| setup-python | v6 | v7 | setup-python-env composite |
| python-coverage-comment-action | v3 | v4.1 (SHA) | v4 uses immutable releases — SHA pin required, tag `@v4` does not exist |
| ruff | v0.16.1 | v0.16.2 | .pre-commit-config.yaml |
| TRIVY_VERSION | v0.70.0 | v0.73.0 | tracer-bullet-ci.yml |

## Tests / validation
- YAML syntax: all 8 changed files parse (PyYAML)
- `pre-commit validate-config`: PASS
- `pre-commit run --files <changed>`: all hooks PASS (yamllint, gitleaks, trailing whitespace, EOF fixer)
- New SHAs verified to resolve to the tagged commits (trivy-action v0.36.0 = `ed142fd`, coverage-comment v4.1 = `5d8df59`)
- Local trivy upgraded 0.72.0 → 0.73.0; confirmed no new findings introduced

## Judgment calls flagged for human review
1. **Terraform 1.9.5 → 1.15.8 is a 6-minor jump.** Local validation on 1.15.8 is green, but CI has historically run on 1.9.5. Terraform 1.15.x also fixes the provider-symlink-init bug hit locally. If this risks breaking the terraform-tests jobs, we can stage it in a separate PR.
2. **KSV-0118 note**: previous session assumed trivy 0.73.0 fixes the KSV-0118 false positive (aquasecurity/trivy#9329) — it does **not**; the issue is still open. The xray-daemon finding remains a false positive (container-level securityContext IS set). No action needed in this PR.
3. Skipped: Node 20 → 24 (EOL April 2026) and `paruff/ufawkespipe` @v1.2.0 (external, no releases API). Happy to do Node in a follow-up.

## What NOT changed
No secrets, no `@main`/`@master` refs remain (verified).