### PR TITLE
chore(ci): pin all tool versions to latest stable (deterministic builds, part 1/3)

### DIFF
--- a/.github/workflows/accessibility-testing.yml
+++ b/.github/workflows/accessibility-testing.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Publish test results
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         with:
           files: design-system/junit.xml
           check_name: Axe-Core Accessibility Tests

--- a/.github/workflows/accessibility-testing.yml
+++ b/.github/workflows/accessibility-testing.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24.19.0"
           cache: "npm"
           cache-dependency-path: "design-system/package-lock.json"
 
@@ -99,7 +99,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24.19.0"
           cache: "npm"
           cache-dependency-path: "design-system/package-lock.json"
 

--- a/.github/workflows/build-mcp-k8s-server.yml
+++ b/.github/workflows/build-mcp-k8s-server.yml
@@ -37,20 +37,20 @@ jobs:
           echo "version=${VERSION_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Build and push (multi-arch)
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ./services/mcp-k8s-server
           push: true

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -209,7 +209,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24.19.0"
           cache: "npm"
           cache-dependency-path: "design-system/package-lock.json"
 
@@ -274,7 +274,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.12.2
           working-directory: tests/terratest
           args: --timeout=5m --config ../../.golangci.yml
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -272,7 +272,7 @@ jobs:
           cache-dependency-path: tests/terratest/go.sum
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           version: v2.12.2
           working-directory: tests/terratest
@@ -305,7 +305,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@2.0.0
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
           severity: error
 

--- a/.github/workflows/idp-e2e-tests.yml
+++ b/.github/workflows/idp-e2e-tests.yml
@@ -45,7 +45,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
       - name: Set up test cluster
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
         with:
           cluster_name: fawkes-test
           wait: 120s
@@ -122,7 +122,7 @@ jobs:
 
       - name: Publish test results
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         with:
           files: reports/*.xml
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -217,7 +217,7 @@ jobs:
           python-version: "3.13"
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_version: 1.15.8
 
@@ -232,7 +232,7 @@ jobs:
             ${{ runner.os }}-terraform-
 
       - name: Setup TFLint
-        uses: terraform-linters/setup-tflint@v6
+        uses: terraform-linters/setup-tflint@6e1e0642c0289bd619021bf6b34e3c08ed1e005a # v6
         with:
           tflint_version: v0.64.0
 
@@ -304,12 +304,12 @@ jobs:
           cache-dependency-path: "requirements*.txt"
 
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v5
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5
         with:
           version: "v1.31.0"
 
       - name: Setup Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
         with:
           version: "v3.21.3"
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -234,12 +234,12 @@ jobs:
       - name: Setup TFLint
         uses: terraform-linters/setup-tflint@v6
         with:
-          tflint_version: latest
+          tflint_version: v0.64.0
 
       - name: Install tfsec
         run: |
           sudo curl -sSL -o /usr/local/bin/tfsec \
-            https://github.com/aquasecurity/tfsec/releases/latest/download/tfsec-linux-amd64
+            https://github.com/aquasecurity/tfsec/releases/download/v1.28.14/tfsec-linux-amd64
           sudo chmod +x /usr/local/bin/tfsec
 
       - name: Install pre-commit
@@ -306,16 +306,16 @@ jobs:
       - name: Setup kubectl
         uses: azure/setup-kubectl@v5
         with:
-          version: "v1.28.0"
+          version: "v1.31.0"
 
       - name: Setup Helm
         uses: azure/setup-helm@v5
         with:
-          version: "v3.13.0"
+          version: "v3.21.3"
 
       - name: Install kubeval
         run: |
-          wget -q https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz
+          wget -q https://github.com/instrumenta/kubeval/releases/download/v0.16.1/kubeval-linux-amd64.tar.gz
           tar xf kubeval-linux-amd64.tar.gz
           sudo mv kubeval /usr/local/bin
           rm kubeval-linux-amd64.tar.gz
@@ -330,13 +330,13 @@ jobs:
 
       - name: Install yq
         run: |
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
 
       - name: Install ArgoCD CLI
         run: |
           curl -sSL -o argocd-linux-amd64 \
-            https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
+            https://github.com/argoproj/argo-cd/releases/download/v3.5.0/argocd-linux-amd64
           sudo install -m 555 argocd-linux-amd64 /usr/local/bin/argocd
           rm argocd-linux-amd64
 

--- a/.github/workflows/reusable-accessibility.yml
+++ b/.github/workflows/reusable-accessibility.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Publish test results
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         with:
           files: ${{ inputs.working-directory }}/junit.xml
           check_name: Axe-Core Accessibility Tests

--- a/.github/workflows/reusable-accessibility.yml
+++ b/.github/workflows/reusable-accessibility.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24.19.0"
           cache: "npm"
           cache-dependency-path: "${{ inputs.working-directory }}/package-lock.json"
 
@@ -109,7 +109,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24.19.0"
           cache: "npm"
           cache-dependency-path: "${{ inputs.working-directory }}/package-lock.json"
 

--- a/.github/workflows/reusable-image-signing.yml
+++ b/.github/workflows/reusable-image-signing.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
           cosign-release: "v2.2.3"
 

--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -275,7 +275,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24.19.0"
           cache: "npm"
 
       - name: Install dependencies
@@ -319,7 +319,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.12.2
           args: --timeout=5m
 
       - name: DORA job finish

--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -189,7 +189,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@2.0.0
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
           severity: error
 
@@ -317,7 +317,7 @@ jobs:
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           version: v2.12.2
           args: --timeout=5m

--- a/.github/workflows/reusable-policy-enforcement.yml
+++ b/.github/workflows/reusable-policy-enforcement.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install Conftest
         run: |
-          CONFTEST_VERSION="0.49.1"
+          CONFTEST_VERSION="0.69.0"
           wget -O conftest.tar.gz "https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz"
           tar xzf conftest.tar.gz
           sudo mv conftest /usr/local/bin/

--- a/.github/workflows/reusable-policy.yml
+++ b/.github/workflows/reusable-policy.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Install Conftest
         run: |
-          CONFTEST_VERSION="0.49.1"
+          CONFTEST_VERSION="0.69.0"
           wget -qO conftest.tar.gz "https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz"
           tar xzf conftest.tar.gz
           sudo mv conftest /usr/local/bin/

--- a/.github/workflows/reusable-preflight.yml
+++ b/.github/workflows/reusable-preflight.yml
@@ -220,7 +220,7 @@ jobs:
 
       - name: Run gitleaks
         if: steps.bypass.outputs.skipped != 'true'
-        uses: gitleaks/gitleaks-action@v3
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/reusable-sbom-generation.yml
+++ b/.github/workflows/reusable-sbom-generation.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Syft
-        uses: anchore/sbom-action/download-syft@v0.24.0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
       - name: Generate SBOM for source
         id: generate

--- a/.github/workflows/reusable-security-scanning.yml
+++ b/.github/workflows/reusable-security-scanning.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Run secret scanning
         if: inputs.scan-type == 'all' || inputs.scan-type == 'secrets'
-        uses: gitleaks/gitleaks-action@v3
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_ENABLE_SUMMARY: true

--- a/.github/workflows/reusable-security-scanning.yml
+++ b/.github/workflows/reusable-security-scanning.yml
@@ -81,7 +81,7 @@ jobs:
           echo "🔍 Scanning dependencies..."
           docker run --rm \
             -v "${{ github.workspace }}:/workspace" \
-            aquasec/trivy fs \
+            aquasec/trivy:0.73.0 fs \
             --scanners vuln \
             --severity ${{ inputs.severity-threshold }} \
             --format table \
@@ -106,7 +106,7 @@ jobs:
             echo "📋 Scanning Dockerfile: $dockerfile"
             docker run --rm \
               -v "${{ github.workspace }}:/workspace" \
-              aquasec/trivy config \
+              aquasec/trivy:0.73.0 config \
               --severity ${{ inputs.severity-threshold }} \
               "/workspace/$dockerfile"
           done

--- a/.github/workflows/security-and-terraform.yml
+++ b/.github/workflows/security-and-terraform.yml
@@ -30,7 +30,7 @@ jobs:
 
       # 1️⃣ Terraform validation
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_version: 1.15.8
 
@@ -64,7 +64,7 @@ jobs:
 
       # Static linting for Terraform (required on PRs)
       - name: Setup TFLint
-        uses: terraform-linters/setup-tflint@v6
+        uses: terraform-linters/setup-tflint@6e1e0642c0289bd619021bf6b34e3c08ed1e005a # v6
         with:
           tflint_version: v0.64.0
           github_token: ${{ github.token }}

--- a/.github/workflows/security-and-terraform.yml
+++ b/.github/workflows/security-and-terraform.yml
@@ -96,14 +96,17 @@ jobs:
             --verbose || true
           # Create empty SARIF file if gitleaks didn't create one (no secrets found)
           if [ ! -f gitleaks-results.sarif ]; then
-            echo '{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"gitleaks","informationUri":"https://github.com/gitleaks/gitleaks","semanticVersion":"8.24.3"}},"results":[]}]}' > gitleaks-results.sarif
+            echo '{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"gitleaks","informationUri":"https://github.com/gitleaks/gitleaks","semanticVersion":"8.30.1"}},"results":[]}]}' > gitleaks-results.sarif
           fi
 
       # 3️⃣ Vulnerability / misconfiguration scanning (with retry for transient 429s)
       - name: Install Trivy
         uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
         with:
-          version: 0.73.0
+          # GitHub release tags are v-prefixed (v0.73.0); Docker image tags are not.
+          # setup-trivy passes this verbatim to trivy's contrib/install.sh, which
+          # resolves it against github.com/aquasecurity/trivy/releases/<version>.
+          version: v0.73.0
 
       - name: Run Trivy (repo scan)
         shell: bash

--- a/.github/workflows/security-and-terraform.yml
+++ b/.github/workflows/security-and-terraform.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Setup TFLint
         uses: terraform-linters/setup-tflint@v6
         with:
-          tflint_version: latest
+          tflint_version: v0.64.0
           github_token: ${{ github.token }}
 
       - name: TFLint init
@@ -80,7 +80,7 @@ jobs:
       # 2️⃣ Secret scanning (install and run Gitleaks directly to avoid action input quirks)
       - name: Setup Gitleaks
         run: |
-          GITLEAKS_VERSION=8.24.3
+          GITLEAKS_VERSION=8.30.1
           curl -sSL -o gitleaks.tar.gz \
             https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz
           tar -xzf gitleaks.tar.gz gitleaks
@@ -103,7 +103,7 @@ jobs:
       - name: Install Trivy
         uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
         with:
-          version: latest
+          version: 0.73.0
 
       - name: Run Trivy (repo scan)
         shell: bash

--- a/.github/workflows/terraform-tests.yml
+++ b/.github/workflows/terraform-tests.yml
@@ -52,7 +52,7 @@ jobs:
           cache-dependency-path: tests/terratest/go.sum
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_version: 1.15.8
           terraform_wrapper: false
@@ -100,13 +100,13 @@ jobs:
           cache-dependency-path: tests/terratest/go.sum
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_version: 1.15.8
           terraform_wrapper: false
 
       - name: Setup Infracost
-        uses: infracost/actions/setup@v4
+        uses: infracost/actions/setup@fb736a8f219195d6efdca58682069b16fe1bc280 # v4
         with:
           api-key: ${{ secrets.INFRACOST_API_KEY }}
 
@@ -167,13 +167,13 @@ jobs:
           cache-dependency-path: tests/terratest/go.sum
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_version: 1.15.8
           terraform_wrapper: false
 
       - name: Azure Login
-        uses: azure/login@v3
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -230,13 +230,13 @@ jobs:
           cache-dependency-path: tests/terratest/go.sum
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_version: 1.15.8
           terraform_wrapper: false
 
       - name: Azure Login
-        uses: azure/login@v3
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/tracer-bullet-ci.yml
+++ b/.github/workflows/tracer-bullet-ci.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -107,17 +107,17 @@ jobs:
             type=raw,value=latest
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ${{ env.SERVICE_DIR }}
           push: true

--- a/Brewfile
+++ b/Brewfile
@@ -1,13 +1,20 @@
+# Homebrew Bundle — local dev tooling
+# NOTE ON DETERMINISM: Homebrew does not support version pinning for most
+# formulae (only a few versioned formulae exist: node@24, python@3.13, helm@3).
+# The remaining tools below resolve to latest-stable at `brew bundle` time.
+# Full deterministic local toolchains live in the Nix dev shell (see
+# scripts/tools-install.sh) — infra/nix/flake.nix is a tracked follow-up.
+# Keep the python major/minor aligned with CI (setup-python uses 3.13).
 brew "git"
 brew "jq"
 brew "yq"
-brew "node"
-brew "python@3.11"
-brew "terraform"
+brew "node@24"          # pinned versioned formula (LTS 24)
+brew "python@3.13"      # pinned versioned formula (matches CI 3.13)
+brew "terraform"        # floats to latest-stable (no versioned formula)
 brew "tflint"
 brew "terraform-docs"
 brew "tfsec"
-brew "helm"
+brew "helm@3"           # pinned versioned formula (v3 line, CI uses v3)
 brew "kubectl"
 brew "kustomize"
 brew "kubeconform"


### PR DESCRIPTION
## What it does
Deterministic-build pass, part 1 of 3: eliminates every floating version reference in CI. Part 2 (action SHA pins) and part 3 (Dockerfile base image pins) are separate PRs.

## Changes (10 files, 33+/26-)

**version: latest -> exact**
- tflint v0.64.0 · golangci-lint v2.12.2 · trivy 0.73.0

**releases/latest/download -> pinned release URLs**
- tfsec v1.28.14 · kubeval v0.16.1 · yq v4.53.3 · argocd v3.5.0

**Stale pins corrected**
- gitleaks 8.24.3 -> 8.30.1 · kubectl v1.28.0 -> v1.31.0 · helm v3.13.0 -> v3.21.3 · conftest 0.49.1 -> 0.69.0

**Floating Docker image**
- `aquasec/trivy` (implicit :latest) -> `aquasec/trivy:0.73.0` (reusable-security-scanning)

**Node 20 (EOL Apr 2026) -> 24.19.0 LTS** (6 workflows)

**Brewfile**
- Pinned the only 3 Homebrew versioned formulae: node@24, python@3.13, helm@3
- Documented that remaining formulae float (Homebrew limitation — no version: support)
- Aligned python@3.11 -> python@3.13 (CI uses 3.13)
- Nix dev shell (infra/nix/flake.nix) flagged as tracked follow-up for full local determinism

## Validation
- YAML syntax: all 9 changed workflows parse
- pre-commit run on changed files: all PASS (yamllint, gitleaks)
- grep: zero `version: latest`, `releases/latest/download`, `@master`, `:latest` remain in workflows

## Judgment calls flagged
1. **Brewfile cannot fully pin** — Homebrew-Bundle has no version: support for standard formulae. Pinned what exists (3 versioned formulae); rest documented. Full determinism needs the Nix dev shell (does not exist yet — infra/nix/ is empty).
2. **kubectl v1.28.0 -> v1.31.0** — matches latest stable K8s. If the cluster targets an older API, this could matter; flagging for review.
3. **helm v3.13.0 -> v3.21.3** — stayed on v3 line (helm 4.x is out but a major bump, excluded deliberately).