### PR TITLE
chore(ci): pin all third-party actions to commit SHA (deterministic builds, part 2/3)

### DIFF
--- a/.github/workflows/accessibility-testing.yml
+++ b/.github/workflows/accessibility-testing.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Publish test results
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         with:
           files: design-system/junit.xml
           check_name: Axe-Core Accessibility Tests

--- a/.github/workflows/build-mcp-k8s-server.yml
+++ b/.github/workflows/build-mcp-k8s-server.yml
@@ -37,20 +37,20 @@ jobs:
           echo "version=${VERSION_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Build and push (multi-arch)
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ./services/mcp-k8s-server
           push: true

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -272,7 +272,7 @@ jobs:
           cache-dependency-path: tests/terratest/go.sum
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           version: v2.12.2
           working-directory: tests/terratest
@@ -305,7 +305,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@2.0.0
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
           severity: error
 

--- a/.github/workflows/idp-e2e-tests.yml
+++ b/.github/workflows/idp-e2e-tests.yml
@@ -45,7 +45,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
       - name: Set up test cluster
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
         with:
           cluster_name: fawkes-test
           wait: 120s
@@ -122,7 +122,7 @@ jobs:
 
       - name: Publish test results
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         with:
           files: reports/*.xml
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -217,7 +217,7 @@ jobs:
           python-version: "3.13"
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_version: 1.15.8
 
@@ -232,7 +232,7 @@ jobs:
             ${{ runner.os }}-terraform-
 
       - name: Setup TFLint
-        uses: terraform-linters/setup-tflint@v6
+        uses: terraform-linters/setup-tflint@6e1e0642c0289bd619021bf6b34e3c08ed1e005a # v6
         with:
           tflint_version: v0.64.0
 
@@ -304,12 +304,12 @@ jobs:
           cache-dependency-path: "requirements*.txt"
 
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v5
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5
         with:
           version: "v1.31.0"
 
       - name: Setup Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
         with:
           version: "v3.21.3"
 

--- a/.github/workflows/reusable-accessibility.yml
+++ b/.github/workflows/reusable-accessibility.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Publish test results
         if: always()
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         with:
           files: ${{ inputs.working-directory }}/junit.xml
           check_name: Axe-Core Accessibility Tests

--- a/.github/workflows/reusable-image-signing.yml
+++ b/.github/workflows/reusable-image-signing.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
           cosign-release: "v2.2.3"
 

--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -189,7 +189,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@2.0.0
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
           severity: error
 
@@ -317,7 +317,7 @@ jobs:
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           version: v2.12.2
           args: --timeout=5m

--- a/.github/workflows/reusable-preflight.yml
+++ b/.github/workflows/reusable-preflight.yml
@@ -220,7 +220,7 @@ jobs:
 
       - name: Run gitleaks
         if: steps.bypass.outputs.skipped != 'true'
-        uses: gitleaks/gitleaks-action@v3
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/reusable-sbom-generation.yml
+++ b/.github/workflows/reusable-sbom-generation.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Syft
-        uses: anchore/sbom-action/download-syft@v0.24.0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
       - name: Generate SBOM for source
         id: generate

--- a/.github/workflows/reusable-security-scanning.yml
+++ b/.github/workflows/reusable-security-scanning.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Run secret scanning
         if: inputs.scan-type == 'all' || inputs.scan-type == 'secrets'
-        uses: gitleaks/gitleaks-action@v3
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_ENABLE_SUMMARY: true

--- a/.github/workflows/security-and-terraform.yml
+++ b/.github/workflows/security-and-terraform.yml
@@ -30,7 +30,7 @@ jobs:
 
       # 1️⃣ Terraform validation
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_version: 1.15.8
 
@@ -64,7 +64,7 @@ jobs:
 
       # Static linting for Terraform (required on PRs)
       - name: Setup TFLint
-        uses: terraform-linters/setup-tflint@v6
+        uses: terraform-linters/setup-tflint@6e1e0642c0289bd619021bf6b34e3c08ed1e005a # v6
         with:
           tflint_version: v0.64.0
           github_token: ${{ github.token }}

--- a/.github/workflows/terraform-tests.yml
+++ b/.github/workflows/terraform-tests.yml
@@ -52,7 +52,7 @@ jobs:
           cache-dependency-path: tests/terratest/go.sum
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_version: 1.15.8
           terraform_wrapper: false
@@ -100,13 +100,13 @@ jobs:
           cache-dependency-path: tests/terratest/go.sum
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_version: 1.15.8
           terraform_wrapper: false
 
       - name: Setup Infracost
-        uses: infracost/actions/setup@v4
+        uses: infracost/actions/setup@fb736a8f219195d6efdca58682069b16fe1bc280 # v4
         with:
           api-key: ${{ secrets.INFRACOST_API_KEY }}
 
@@ -167,13 +167,13 @@ jobs:
           cache-dependency-path: tests/terratest/go.sum
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_version: 1.15.8
           terraform_wrapper: false
 
       - name: Azure Login
-        uses: azure/login@v3
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -230,13 +230,13 @@ jobs:
           cache-dependency-path: tests/terratest/go.sum
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_version: 1.15.8
           terraform_wrapper: false
 
       - name: Azure Login
-        uses: azure/login@v3
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 

--- a/.github/workflows/tracer-bullet-ci.yml
+++ b/.github/workflows/tracer-bullet-ci.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
@@ -107,17 +107,17 @@ jobs:
             type=raw,value=latest
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ${{ env.SERVICE_DIR }}
           push: true


### PR DESCRIPTION
## What it does
Deterministic-build pass, part 2 of 3. Stacks on #1550 (PR A) because 7 files overlap. Once #1550 merges, this PR's base auto-updates to main and the diff stays clean.

GitHub hardening guidance: SHA-pin every action NOT published by the `actions/*` or `github/*` orgs.

## Changes (14 files, 33+/33-)
19 refs pinned (18 unique actions), each with trailing `# <tag>` comment:
- docker: build-push v7, login v4, metadata v6, setup-buildx v4, setup-qemu v4
- EnricoMi/publish-unit-test-result-action v2 (x3)
- gitleaks/gitleaks-action v3 (x2), golangci/golangci-lint-action v9 (x2)
- hashicorp/setup-terraform v4 (x6), terraform-linters/setup-tflint v6 (x2)
- helm/kind-action v1, ludeeus/action-shellcheck 2.0.0 (x2), sigstore/cosign-installer v4.1.2
- **NEW vs earlier audit (missed by first pass)**: azure/login v3, azure/setup-helm v5,
  azure/setup-kubectl v5, anchore/sbom-action/download-syft v0.24.0, infracost/actions/setup v4

Trusted, left floating per GitHub guidance: `actions/*`, `github/codeql-action/*`,
`paruff/ufawkespipe@v1.2.0` (own org, release tag).

## Judgment calls flagged
1. **4 SHAs differ from first-pass resolution** (golangci-lint-action v9, kind-action v1,
   setup-tflint v6, publish-unit-test-result v2) — these major tags were re-pointed by
   maintainers between passes. All pins use the fresh tag->SHA resolution.
2. **Stacked on #1550** — unavoidable without human-merge sequencing; PR A's branch is
   the base. Review order: #1550 first, then this.

## Validation
- YAML syntax: all 14 changed workflows parse
- pre-commit run on changed files: all PASS (yamllint, gitleaks)
- grep: zero floating third-party tags remain outside actions/*, github/*, paruff/*