### PR TITLE
chore(docker): pin all base images to exact published tags (deterministic builds, part 3/3)

### DIFF
--- a/design-system/Dockerfile
+++ b/design-system/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM node:18-alpine AS builder
+FROM node:24.19.0-alpine AS builder
 
 WORKDIR /app
 
@@ -16,7 +16,7 @@ COPY . .
 RUN npm run build-storybook
 
 # Stage 2: Serve
-FROM nginx:alpine
+FROM nginx:1.28.3-alpine
 
 # Create non-root user for running nginx
 RUN addgroup -g 1000 nginx-user && \

--- a/design-system/Dockerfile.prebuilt
+++ b/design-system/Dockerfile.prebuilt
@@ -1,5 +1,5 @@
 # Dockerfile for pre-built Storybook
-FROM nginx:alpine
+FROM nginx:1.28.3-alpine
 
 # Create non-root user for running nginx
 RUN addgroup -g 1000 nginx-user && \

--- a/extensions/ai/services/rag/Dockerfile
+++ b/extensions/ai/services/rag/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage Dockerfile for RAG Service
 # Stage 1: Build
-FROM python:3.13-slim AS build
+FROM python:3.13.14-slim AS build
 WORKDIR /app
 
 # Update packages for security
@@ -15,7 +15,7 @@ RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
 
 # Stage 2: Runtime
-FROM python:3.13-slim
+FROM python:3.13.14-slim
 WORKDIR /app
 
 # Update packages for security

--- a/infra/mcp-k8s-server/Dockerfile
+++ b/infra/mcp-k8s-server/Dockerfile
@@ -1,5 +1,5 @@
 # Minimal image for FastAPI + Kubernetes client
-FROM python:3.13-slim
+FROM python:3.13.14-slim
 WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1

--- a/platform/apps/opentelemetry/sample-app/Dockerfile
+++ b/platform/apps/opentelemetry/sample-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.13.14-slim
 
 WORKDIR /app
 

--- a/services/ai-code-review/Dockerfile
+++ b/services/ai-code-review/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage Dockerfile for AI Code Review Service
 # Stage 1: Build
-FROM python:3.13-slim AS build
+FROM python:3.13.14-slim AS build
 WORKDIR /app
 
 # Update packages for security
@@ -15,7 +15,7 @@ RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
 
 # Stage 2: Runtime
-FROM python:3.13-slim
+FROM python:3.13.14-slim
 WORKDIR /app
 
 # Update packages for security

--- a/services/analytics-dashboard/Dockerfile
+++ b/services/analytics-dashboard/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.13.14-slim
 
 WORKDIR /app
 

--- a/services/anomaly-detection/Dockerfile
+++ b/services/anomaly-detection/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage Dockerfile for Anomaly Detection Service
 # Stage 1: Build
-FROM python:3.13-slim AS build
+FROM python:3.13.14-slim AS build
 WORKDIR /app
 
 # Update packages for security
@@ -15,7 +15,7 @@ RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
 
 # Stage 2: Runtime
-FROM python:3.13-slim
+FROM python:3.13.14-slim
 WORKDIR /app
 
 # Update packages for security

--- a/services/devex-survey-automation/Dockerfile
+++ b/services/devex-survey-automation/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.13.14-slim
 
 WORKDIR /app
 

--- a/services/discovery-metrics/Dockerfile
+++ b/services/discovery-metrics/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.13.14-slim
 
 WORKDIR /app
 

--- a/services/dora-metrics/Dockerfile
+++ b/services/dora-metrics/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim AS base
+FROM python:3.13.14-slim AS base
 
 WORKDIR /app
 

--- a/services/experimentation/Dockerfile
+++ b/services/experimentation/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.13.14-slim
 
 WORKDIR /app
 

--- a/services/feedback-bot/Dockerfile
+++ b/services/feedback-bot/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.13.14-slim
 
 # Set working directory
 WORKDIR /app

--- a/services/feedback/Dockerfile
+++ b/services/feedback/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage Dockerfile for Feedback Service
 # Stage 1: Build
-FROM python:3.13-slim AS build
+FROM python:3.13.14-slim AS build
 WORKDIR /app
 
 # Update packages for security
@@ -15,7 +15,7 @@ RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
 
 # Stage 2: Runtime
-FROM python:3.13-slim
+FROM python:3.13.14-slim
 WORKDIR /app
 
 # Update packages for security

--- a/services/friction-bot/Dockerfile
+++ b/services/friction-bot/Dockerfile
@@ -1,7 +1,7 @@
 # Multi-stage Dockerfile for Friction Bot
 
 # Stage 1: Builder
-FROM python:3.13-slim AS builder
+FROM python:3.13.14-slim AS builder
 
 WORKDIR /app
 
@@ -12,7 +12,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir --user -r requirements.txt
 
 # Stage 2: Runtime
-FROM python:3.13-slim
+FROM python:3.13.14-slim
 
 # Create non-root user
 RUN useradd --create-home --uid 10001 appuser

--- a/services/insights/Dockerfile
+++ b/services/insights/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage Dockerfile for Insights Service
 # Stage 1: Build
-FROM python:3.13-slim AS build
+FROM python:3.13.14-slim AS build
 WORKDIR /app
 
 # Update packages for security
@@ -15,7 +15,7 @@ RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
 
 # Stage 2: Runtime
-FROM python:3.13-slim
+FROM python:3.13.14-slim
 WORKDIR /app
 
 # Update packages for security

--- a/services/mcp-k8s-server/Dockerfile
+++ b/services/mcp-k8s-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim
+FROM python:3.14.6-slim
 ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 

--- a/services/nps/Dockerfile
+++ b/services/nps/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage Dockerfile for NPS Survey Service
 # Stage 1: Build
-FROM python:3.13-slim AS build
+FROM python:3.13.14-slim AS build
 WORKDIR /app
 
 # Update packages for security
@@ -15,7 +15,7 @@ RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
 
 # Stage 2: Runtime
-FROM python:3.13-slim
+FROM python:3.13.14-slim
 WORKDIR /app
 
 # Update packages for security

--- a/services/samples/sample-java-app/Dockerfile
+++ b/services/samples/sample-java-app/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage Dockerfile for Java Spring Boot
 # Stage 1: Build
-FROM maven:3.9-eclipse-temurin-21 AS build
+FROM maven:3.9.16-eclipse-temurin-21 AS build
 WORKDIR /app
 
 # Copy pom.xml and download dependencies (layer caching)
@@ -12,7 +12,7 @@ COPY src ./src
 RUN mvn clean package -DskipTests
 
 # Stage 2: Runtime
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:21.0.11_10-jre-alpine
 WORKDIR /app
 
 # Update packages and install netcat for healthcheck

--- a/services/samples/sample-nodejs-app/Dockerfile
+++ b/services/samples/sample-nodejs-app/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage Dockerfile for Node.js Express
 # Stage 1: Build
-FROM node:20-alpine AS build
+FROM node:24.19.0-alpine AS build
 WORKDIR /app
 
 # Update packages for security
@@ -14,7 +14,7 @@ COPY package*.json ./
 RUN npm ci --only=production
 
 # Stage 2: Runtime
-FROM node:20-alpine
+FROM node:24.19.0-alpine
 WORKDIR /app
 
 # Update packages for security

--- a/services/samples/sample-python-app/Dockerfile
+++ b/services/samples/sample-python-app/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage Dockerfile for Python FastAPI
 # Stage 1: Build
-FROM python:3.13-slim AS build
+FROM python:3.13.14-slim AS build
 WORKDIR /app
 
 # Update packages for security
@@ -15,7 +15,7 @@ RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
 
 # Stage 2: Runtime
-FROM python:3.13-slim
+FROM python:3.13.14-slim
 WORKDIR /app
 
 # Update packages for security

--- a/services/smart-alerting/Dockerfile
+++ b/services/smart-alerting/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.13.14-slim
 
 WORKDIR /app
 

--- a/services/space-metrics/Dockerfile
+++ b/services/space-metrics/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.13.14-slim
 
 WORKDIR /app
 

--- a/services/tracer-bullet/Dockerfile
+++ b/services/tracer-bullet/Dockerfile
@@ -2,7 +2,7 @@
 # =============================================================================
 
 # --- Build stage ---
-FROM python:3.13-slim AS builder
+FROM python:3.13.14-slim AS builder
 
 WORKDIR /build
 
@@ -10,7 +10,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
 
 # --- Runtime stage ---
-FROM python:3.13-slim AS runtime
+FROM python:3.13.14-slim AS runtime
 
 # Security: upgrade packages, create non-root user
 RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*

--- a/services/vsm/Dockerfile
+++ b/services/vsm/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage Dockerfile for VSM Service
 # Stage 1: Build
-FROM python:3.13-slim AS build
+FROM python:3.13.14-slim AS build
 WORKDIR /app
 
 # Update packages for security
@@ -15,7 +15,7 @@ RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
 
 # Stage 2: Runtime
-FROM python:3.13-slim
+FROM python:3.13.14-slim
 WORKDIR /app
 
 # Update packages for security

--- a/templates/java-service/skeleton/Dockerfile
+++ b/templates/java-service/skeleton/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage Dockerfile for Java Spring Boot
 # Stage 1: Build
-FROM maven:3.9-eclipse-temurin-21 AS build
+FROM maven:3.9.16-eclipse-temurin-21 AS build
 WORKDIR /app
 
 # Copy pom.xml and download dependencies (layer caching)
@@ -12,7 +12,7 @@ COPY src ./src
 RUN mvn clean package -DskipTests
 
 # Stage 2: Runtime
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:21.0.11_10-jre-alpine
 WORKDIR /app
 
 # Update packages and install netcat for healthcheck

--- a/templates/nodejs-service/skeleton/Dockerfile
+++ b/templates/nodejs-service/skeleton/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage Dockerfile for Node.js Express
 # Stage 1: Build
-FROM node:20-alpine AS build
+FROM node:24.19.0-alpine AS build
 WORKDIR /app
 
 # Update packages for security
@@ -14,7 +14,7 @@ COPY package*.json ./
 RUN npm ci --only=production
 
 # Stage 2: Runtime
-FROM node:20-alpine
+FROM node:24.19.0-alpine
 WORKDIR /app
 
 # Update packages for security

--- a/templates/python-service/skeleton/Dockerfile
+++ b/templates/python-service/skeleton/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage Dockerfile for Python FastAPI
 # Stage 1: Build
-FROM python:3.13-slim AS build
+FROM python:3.13.14-slim AS build
 WORKDIR /app
 
 # Update packages for security
@@ -15,7 +15,7 @@ RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
 
 # Stage 2: Runtime
-FROM python:3.13-slim
+FROM python:3.13.14-slim
 WORKDIR /app
 
 # Update packages for security


### PR DESCRIPTION
## What it does
Deterministic-build pass, part 3 of 3. Standalone PR (no file overlap with #1550/#1551).

Pins every floating Docker base image to an immutable published tag. Also upgrades EOL runtimes to latest stable (Node 18/20 are EOL).

## Changes (28 files, 44+/44-)

| Floating | Pinned | Notes |
|---|---|---|
| python:3.13-slim (32 refs) | python:3.13.14-slim | latest PUBLISHED 3.13.x patch; python.org 3.13.15 not yet on Docker Hub |
| python:3.14-slim (1) | python:3.14.6-slim | mcp-k8s-server |
| node:20-alpine (4) | node:24.19.0-alpine | Node 20 EOL Apr 2026 |
| node:18-alpine (1) | node:24.19.0-alpine | Node 18 EOL Apr 2025 |
| nginx:alpine (2) | nginx:1.28.3-alpine | design-system |
| maven:3.9-eclipse-temurin-21 (2) | maven:3.9.16-eclipse-temurin-21 | java template + sample |
| eclipse-temurin:21-jre-alpine (2) | eclipse-temurin:21.0.11_10-jre-alpine | java template + sample |

All versions verified as published on Docker Hub (2026-08-08).

## Judgment calls flagged
1. **python 3.13.15 (python.org) not used** — Docker Hub has not published it; pinned to 3.13.14 which IS published. A follow-up bump to 3.13.15-slim is a one-line change once it lands.
2. **Node 18/20 -> 24** is an upgrade, not just a pin (EOL runtimes). Backward compatible for typical apps; flagged since it changes runtime major for sample apps and templates.

## Validation
- grep: zero floating `FROM` base images remain (python:3.13-/3.14-, node:18/20-, nginx:alpine, maven:3.9-eclipse, temurin:21-jre)
- pre-commit: PASS (gitleaks, whitespace)