### PR TITLE
infra(aws): bootstrap Terraform state S3+DynamoDB backend

### DIFF
--- a/infra/aws/bootstrap/.terraform.lock.hcl
+++ b/infra/aws/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.58.0"
+  constraints = ">= 5.0.0, ~> 6.0"
+  hashes = [
+    "h1:1im6ypdeXLXq3sHElserTE62qmIqNiHLAyC3R5EnFFw=",
+    "zh:1221253beee5629fb503d79cebc9bc661279cbc4be5d01db9ab4c1b702108250",
+    "zh:132bd0925bdc4b72446ac750b7ccb1e19b9ba8fbb6df57b2c1423314d2195d4f",
+    "zh:18cda250b9e82b753808715893c8927f132273c00ffae7a697d65ac1cb577e48",
+    "zh:204c944f1fb7f440a335bb2083c9691a9d1f677aea9701025dd5816aee41f0ba",
+    "zh:2dc41df289f2b10a01e650cdd73699955f0ab0645d09cfb114a8cd0f4cc4ede7",
+    "zh:345633dfa9a234659d52aadd126e6dce658518c3ab5cbf6d871221287ed5ec56",
+    "zh:4dadcced73e742903158bc9838936d911f3fa4c2c37b5591c1a28f8f2a1902a6",
+    "zh:5bc60cc2b8c093da98b211d9f6c21c9ecec0f21b944d9ecbe3961fba33086e80",
+    "zh:6cc8f084938b0033a9c0c910989919dad6b1683e76e0afa1a5c604e39f398a75",
+    "zh:7db214647f79de9a033b5dfd6cbfaa42d53c4d056b32cb3acc7ad99306dd548a",
+    "zh:9078589ec881cee7ed9403af262c98ff257fb3e1baae72ff6429a398b1c730af",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:bd5bce6aec4d4922b1127b8575688bd4bc4279670ee28d198ede404709826c7c",
+    "zh:cd900ecf56d21023873898b06e40234f3f4d350f2343b7d9b980d6c5cb604fae",
+    "zh:dbe93b276a84421026b956c3c5b4eb8897da6cbb54b93cb89f5d6ebbd30805ca",
+    "zh:f6b6c7bb2dbf04ee085e5c22f7a65b3ccaebf368ed95584dc0dfee8a22771056",
+  ]
+}

--- a/infra/aws/bootstrap/main.tf
+++ b/infra/aws/bootstrap/main.tf
@@ -1,0 +1,85 @@
+# Copyright (c) 2025  Philip Ruff
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+# OR OTHER DEALINGS IN THE SOFTWARE.
+
+# =============================================================================
+# Terraform State Backend Bootstrap (#1569)
+# =============================================================================
+# Provisions the S3 bucket + DynamoDB lock table that ../backend.tf expects.
+# This config deliberately uses LOCAL state — it must exist before the
+# remote backend it creates can be used, so it cannot depend on itself.
+#
+# One-time usage:
+#   cd infra/aws/bootstrap
+#   terraform init
+#   terraform apply
+#
+# Then migrate the main config to the resulting backend:
+#   cd ../
+#   terraform init -backend-config=backend.hcl -migrate-state
+#
+# Requires AWS credentials with permission to create S3 buckets and
+# DynamoDB tables. Run once per AWS account; re-running is safe (idempotent).
+# =============================================================================
+
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+module "state_bucket" {
+  source = "../../terraform/modules/aws/s3"
+
+  bucket_name       = var.bucket_name
+  enable_versioning = true
+  sse_algorithm     = "AES256"
+
+  tags = {
+    Project   = "fawkes"
+    Purpose   = "terraform-remote-state"
+    ManagedBy = "terraform-bootstrap"
+  }
+}
+
+resource "aws_dynamodb_table" "lock" {
+  name         = var.dynamodb_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = {
+    Project   = "fawkes"
+    Purpose   = "terraform-state-locking"
+    ManagedBy = "terraform-bootstrap"
+  }
+}

--- a/infra/aws/bootstrap/outputs.tf
+++ b/infra/aws/bootstrap/outputs.tf
@@ -1,0 +1,41 @@
+# Copyright (c) 2025  Philip Ruff
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+# OR OTHER DEALINGS IN THE SOFTWARE.
+
+output "bucket_name" {
+  description = "Name of the created Terraform state S3 bucket"
+  value       = module.state_bucket.bucket_id
+}
+
+output "dynamodb_table_name" {
+  description = "Name of the created Terraform state lock DynamoDB table"
+  value       = aws_dynamodb_table.lock.name
+}
+
+output "backend_config_command" {
+  description = "Command to run from infra/aws/ to migrate to this backend"
+  value       = <<-EOT
+    terraform init \
+      -backend-config="bucket=${module.state_bucket.bucket_id}" \
+      -backend-config="key=aws/terraform.tfstate" \
+      -backend-config="region=${var.region}" \
+      -backend-config="dynamodb_table=${aws_dynamodb_table.lock.name}" \
+      -migrate-state
+  EOT
+}

--- a/infra/aws/bootstrap/variables.tf
+++ b/infra/aws/bootstrap/variables.tf
@@ -1,0 +1,37 @@
+# Copyright (c) 2025  Philip Ruff
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+# OR OTHER DEALINGS IN THE SOFTWARE.
+
+variable "region" {
+  description = "AWS region to provision the state bucket and lock table in"
+  type        = string
+  default     = "us-east-2"
+}
+
+variable "bucket_name" {
+  description = "S3 bucket name for Terraform remote state (must match backend.tf usage)"
+  type        = string
+  default     = "fawkes-terraform-state"
+}
+
+variable "dynamodb_table_name" {
+  description = "DynamoDB table name for Terraform state locking (must match backend.tf usage)"
+  type        = string
+  default     = "fawkes-terraform-locks"
+}


### PR DESCRIPTION
## What
Part of MVP P0 issue #1569. Adds `infra/aws/bootstrap/` — a small local-state Terraform config that provisions the S3 bucket + DynamoDB lock table `infra/aws/backend.tf` already expects (bucket/table names match; that file's stub was already correctly written, just nothing existed to create the resources it references).

## Layer(s) touched
`infra/aws/` (new `bootstrap/` subdirectory) — flagging per AGENTS.md's "infra/ changes require a second human reviewer" rule.

## Why this scope, not the full issue
This environment has no valid AWS credentials (`aws sts get-caller-identity` fails with `InvalidClientTokenId`). Issue #1569 explicitly anticipates this: *"If no real AWS account is available, this issue's scope is: get the Terraform config ready... and clearly document the exact terraform init -backend-config=... command for whoever has account access — not to fabricate/guess bucket names into production."* This PR is that scope.

**Not done, needs a human with real AWS access:**
- Running `terraform apply` in `infra/aws/bootstrap/` to actually create the bucket/table
- Running the `terraform init -migrate-state` command (exact command is a Terraform output: `backend_config_command`)
- Closing #1153 or correcting #646's premature closure — both need live verification I can't perform here

**Verified, not just assumed:** `infra/azure/` has no backend stub at all (not even commented out like AWS's), so there's nothing equivalent to repeat there.

## Tests
`terraform fmt -check`, `terraform validate`, and `tflint` all pass (ran locally; also part of this repo's pre-commit hooks, which passed on the commit). `terraform plan`/`apply` can't be tested without real AWS credentials.

## Judgment calls for review
- Reused the existing `infra/terraform/modules/aws/s3` module for the bucket (versioning + AES256 encryption + public-access-block) rather than writing bucket config from scratch.
- DynamoDB table uses `PAY_PER_REQUEST` billing (no existing dynamodb module to reuse) — cheapest option for a low-traffic lock table.
- Bootstrap config deliberately does not use the S3 backend it creates (local state) — avoids the chicken-and-egg problem of a backend depending on itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)