### PR TITLE
infra(aws): IRSA support for eks-namespace module, wire tracer-bullet

### DIFF
--- a/infra/aws/main.tf
+++ b/infra/aws/main.tf
@@ -33,18 +33,6 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.6"
     }
-    time = {
-      source  = "hashicorp/time"
-      version = ">= 0.9.0"
-    }
-    tls = {
-      source  = "hashicorp/tls"
-      version = ">= 4.0.0"
-    }
-    cloudinit = {
-      source  = "hashicorp/cloudinit"
-      version = ">= 2.0.0"
-    }
   }
 }
 
@@ -249,6 +237,21 @@ module "eks" {
   tags = local.tags
 }
 
+module "tracer_bullet_irsa" {
+  source = "../terraform/modules/aws/eks-namespace"
+
+  namespace = "fawkes"
+  # ArgoCD owns namespace creation via CreateNamespace=true
+  # (platform/apps/tracer-bullet/tracer-bullet-application.yaml) — this
+  # module call only manages the IRSA role, not the namespace object.
+  manage_namespace     = false
+  create_irsa_role     = true
+  service_account_name = "tracer-bullet"
+  oidc_provider_arn    = module.eks.oidc_provider_arn
+  oidc_provider_url    = module.eks.oidc_provider
+  iam_policy_arns      = []
+}
+
 data "aws_eks_cluster" "cluster" {
   name = module.eks.cluster_name
 }
@@ -258,14 +261,21 @@ data "aws_eks_cluster_auth" "cluster" {
 }
 
 output "cluster_name" {
-  value = module.eks.cluster_name
+  description = "Name of the EKS cluster."
+  value       = module.eks.cluster_name
 }
 
 output "cluster_endpoint" {
-  value = data.aws_eks_cluster.cluster.endpoint
+  description = "API server endpoint of the EKS cluster."
+  value       = data.aws_eks_cluster.cluster.endpoint
 }
 
-
 output "vpc_id" {
-  value = module.vpc.vpc_id
+  description = "ID of the VPC created for the EKS cluster."
+  value       = module.vpc.vpc_id
+}
+
+output "tracer_bullet_irsa_role_arn" {
+  description = "IAM role ARN for tracer-bullet's IRSA-bound ServiceAccount."
+  value       = module.tracer_bullet_irsa.irsa_role_arn
 }

--- a/infra/aws/outputs.tf
+++ b/infra/aws/outputs.tf
@@ -23,7 +23,7 @@ output "cluster_security_group_id" {
   value       = module.eks.cluster_security_group_id
 }
 
-// kubectl config and aws-auth outputs removed in eks module v19
+# kubectl config and aws-auth outputs removed in eks module v19
 
 output "region" {
   description = "AWS region."

--- a/infra/terraform/modules/aws/eks-namespace/.terraform.lock.hcl
+++ b/infra/terraform/modules/aws/eks-namespace/.terraform.lock.hcl
@@ -1,6 +1,30 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.58.0"
+  constraints = ">= 5.0.0"
+  hashes = [
+    "h1:1im6ypdeXLXq3sHElserTE62qmIqNiHLAyC3R5EnFFw=",
+    "zh:1221253beee5629fb503d79cebc9bc661279cbc4be5d01db9ab4c1b702108250",
+    "zh:132bd0925bdc4b72446ac750b7ccb1e19b9ba8fbb6df57b2c1423314d2195d4f",
+    "zh:18cda250b9e82b753808715893c8927f132273c00ffae7a697d65ac1cb577e48",
+    "zh:204c944f1fb7f440a335bb2083c9691a9d1f677aea9701025dd5816aee41f0ba",
+    "zh:2dc41df289f2b10a01e650cdd73699955f0ab0645d09cfb114a8cd0f4cc4ede7",
+    "zh:345633dfa9a234659d52aadd126e6dce658518c3ab5cbf6d871221287ed5ec56",
+    "zh:4dadcced73e742903158bc9838936d911f3fa4c2c37b5591c1a28f8f2a1902a6",
+    "zh:5bc60cc2b8c093da98b211d9f6c21c9ecec0f21b944d9ecbe3961fba33086e80",
+    "zh:6cc8f084938b0033a9c0c910989919dad6b1683e76e0afa1a5c604e39f398a75",
+    "zh:7db214647f79de9a033b5dfd6cbfaa42d53c4d056b32cb3acc7ad99306dd548a",
+    "zh:9078589ec881cee7ed9403af262c98ff257fb3e1baae72ff6429a398b1c730af",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:bd5bce6aec4d4922b1127b8575688bd4bc4279670ee28d198ede404709826c7c",
+    "zh:cd900ecf56d21023873898b06e40234f3f4d350f2343b7d9b980d6c5cb604fae",
+    "zh:dbe93b276a84421026b956c3c5b4eb8897da6cbb54b93cb89f5d6ebbd30805ca",
+    "zh:f6b6c7bb2dbf04ee085e5c22f7a65b3ccaebf368ed95584dc0dfee8a22771056",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "3.2.1"
   constraints = ">= 2.25.0"

--- a/infra/terraform/modules/aws/eks-namespace/main.tf
+++ b/infra/terraform/modules/aws/eks-namespace/main.tf
@@ -32,9 +32,13 @@ locals {
 }
 
 # ---------------------------------------------------------------------------
-# Namespace
+# Namespace (optional — skip when a GitOps controller like ArgoCD already
+# owns namespace creation via CreateNamespace=true, and this module is only
+# being used for its IRSA support)
 # ---------------------------------------------------------------------------
 resource "kubernetes_namespace" "app" {
+  count = var.manage_namespace ? 1 : 0
+
   metadata {
     name   = var.namespace
     labels = local.labels
@@ -45,11 +49,11 @@ resource "kubernetes_namespace" "app" {
 # Resource Quota (optional)
 # ---------------------------------------------------------------------------
 resource "kubernetes_resource_quota" "app" {
-  count = var.resource_quota != null ? 1 : 0
+  count = var.manage_namespace && var.resource_quota != null ? 1 : 0
 
   metadata {
     name      = "${var.namespace}-quota"
-    namespace = kubernetes_namespace.app.metadata[0].name
+    namespace = kubernetes_namespace.app[0].metadata[0].name
   }
 
   spec {
@@ -67,15 +71,60 @@ resource "kubernetes_resource_quota" "app" {
 # Network Policy — default deny-all (optional)
 # ---------------------------------------------------------------------------
 resource "kubernetes_network_policy" "default_deny" {
-  count = var.network_policy ? 1 : 0
+  count = var.manage_namespace && var.network_policy ? 1 : 0
 
   metadata {
     name      = "default-deny-all"
-    namespace = kubernetes_namespace.app.metadata[0].name
+    namespace = kubernetes_namespace.app[0].metadata[0].name
   }
 
   spec {
     pod_selector {}
     policy_types = ["Ingress", "Egress"]
   }
+}
+
+# ---------------------------------------------------------------------------
+# IRSA (optional) — IAM role assumable by a Kubernetes ServiceAccount via
+# the cluster's OIDC provider, scoped to this namespace + service account.
+# ---------------------------------------------------------------------------
+data "aws_iam_policy_document" "irsa_trust" {
+  count = var.create_irsa_role ? 1 : 0
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [var.oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${var.oidc_provider_url}:sub"
+      values   = ["system:serviceaccount:${var.namespace}:${var.service_account_name}"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${var.oidc_provider_url}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "irsa" {
+  count = var.create_irsa_role ? 1 : 0
+
+  name               = coalesce(var.iam_role_name, "${var.namespace}-${var.service_account_name}-irsa")
+  assume_role_policy = data.aws_iam_policy_document.irsa_trust[0].json
+  tags               = local.labels
+}
+
+resource "aws_iam_role_policy_attachment" "irsa" {
+  for_each = var.create_irsa_role ? toset(var.iam_policy_arns) : toset([])
+
+  role       = aws_iam_role.irsa[0].name
+  policy_arn = each.value
 }

--- a/infra/terraform/modules/aws/eks-namespace/outputs.tf
+++ b/infra/terraform/modules/aws/eks-namespace/outputs.tf
@@ -19,11 +19,21 @@
 # OR OTHER DEALINGS IN THE SOFTWARE.
 
 output "namespace_name" {
-  description = "Name of the created Kubernetes namespace"
-  value       = kubernetes_namespace.app.metadata[0].name
+  description = "Name of the created Kubernetes namespace (null if manage_namespace is false)"
+  value       = var.manage_namespace ? kubernetes_namespace.app[0].metadata[0].name : null
 }
 
 output "namespace_uid" {
-  description = "UID of the created Kubernetes namespace"
-  value       = kubernetes_namespace.app.metadata[0].uid
+  description = "UID of the created Kubernetes namespace (null if manage_namespace is false)"
+  value       = var.manage_namespace ? kubernetes_namespace.app[0].metadata[0].uid : null
+}
+
+output "irsa_role_arn" {
+  description = "ARN of the IRSA IAM role (null if create_irsa_role is false)"
+  value       = var.create_irsa_role ? aws_iam_role.irsa[0].arn : null
+}
+
+output "irsa_role_name" {
+  description = "Name of the IRSA IAM role (null if create_irsa_role is false)"
+  value       = var.create_irsa_role ? aws_iam_role.irsa[0].name : null
 }

--- a/infra/terraform/modules/aws/eks-namespace/variables.tf
+++ b/infra/terraform/modules/aws/eks-namespace/variables.tf
@@ -51,3 +51,45 @@ variable "network_policy" {
   type        = bool
   default     = false
 }
+
+variable "manage_namespace" {
+  description = "Whether this module creates the Kubernetes namespace. Set false when a GitOps controller (e.g. ArgoCD with CreateNamespace=true) already owns it and this module is only used for IRSA."
+  type        = bool
+  default     = true
+}
+
+variable "create_irsa_role" {
+  description = "Whether to create an IAM role assumable by a Kubernetes ServiceAccount via IRSA"
+  type        = bool
+  default     = false
+}
+
+variable "service_account_name" {
+  description = "Kubernetes ServiceAccount name the IRSA role trusts (required if create_irsa_role is true)"
+  type        = string
+  default     = null
+}
+
+variable "oidc_provider_arn" {
+  description = "ARN of the EKS cluster's IAM OIDC provider, e.g. module.eks.oidc_provider_arn (required if create_irsa_role is true)"
+  type        = string
+  default     = null
+}
+
+variable "oidc_provider_url" {
+  description = "Issuer URL of the EKS cluster's OIDC provider without the https:// prefix, e.g. module.eks.oidc_provider (required if create_irsa_role is true)"
+  type        = string
+  default     = null
+}
+
+variable "iam_policy_arns" {
+  description = "IAM policy ARNs to attach to the IRSA role"
+  type        = list(string)
+  default     = []
+}
+
+variable "iam_role_name" {
+  description = "Name for the IRSA IAM role. Defaults to \"<namespace>-<service_account_name>-irsa\" if not set"
+  type        = string
+  default     = null
+}

--- a/infra/terraform/modules/aws/eks-namespace/versions.tf
+++ b/infra/terraform/modules/aws/eks-namespace/versions.tf
@@ -31,5 +31,9 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = ">= 2.25.0"
     }
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
   }
 }

--- a/platform/apps/tracer-bullet/serviceaccount.yaml
+++ b/platform/apps/tracer-bullet/serviceaccount.yaml
@@ -23,6 +23,11 @@ kind: ServiceAccount
 metadata:
   name: tracer-bullet
   namespace: fawkes
+  annotations:
+    # ARN comes from `terraform output tracer_bullet_irsa_role_arn` in
+    # infra/aws/ after apply (infra/terraform/modules/aws/eks-namespace, #1570).
+    # Replace once that output is available; not yet substituted automatically.
+    eks.amazonaws.com/role-arn: "REPLACE_WITH_TERRAFORM_OUTPUT_tracer_bullet_irsa_role_arn"
   labels:
     app: tracer-bullet
     app.kubernetes.io/name: tracer-bullet


### PR DESCRIPTION
## What
Part of MVP P0 issue #1570. Adds IRSA (IAM Roles for Service Accounts) support to `infra/terraform/modules/aws/eks-namespace/` and wires it into `infra/aws/main.tf` for tracer-bullet.

## Layer(s) touched
`infra/terraform/modules/aws/` (module) and `infra/aws/` (root config) — flagging per AGENTS.md's "infra/ changes require a second human reviewer" and "Adding a Terraform provider/module" rules. Also `platform/apps/tracer-bullet/serviceaccount.yaml` (annotation only).

## Tracker correction
Issue #82 / #1570 claimed no `eks-app-namespace` module existed. It does (`infra/terraform/modules/aws/eks-namespace/`), just unwired and missing IRSA. Verified by grepping for any caller (none) and for `irsa`/`iam_role` anywhere in `infra/`/`platform/` (none) before writing this.

## Design notes
- Added a `manage_namespace` toggle (default `true`, so this is backward-compatible for any future caller). tracer-bullet's `fawkes` namespace is already created by ArgoCD (`CreateNamespace=true` in `tracer-bullet-application.yaml`), so the wiring passes `manage_namespace = false` — having Terraform also try to own that namespace object would fight ArgoCD.
- The IRSA trust policy only needs namespace/service-account *names* as strings (OIDC `sub` claim), so it works fine even when `manage_namespace = false`.
- `serviceaccount.yaml` gets a placeholder `eks.amazonaws.com/role-arn` annotation. This repo has no envsubst/substitution pipeline for ArgoCD-managed manifests (checked — only imperative `kubectl apply` examples elsewhere use `${VAR}` placeholders, which don't fit GitOps reconciliation). The real ARN needs to be filled in manually from `terraform output tracer_bullet_irsa_role_arn` after apply, until that's automated — flagging as a judgment call.
- Fixed pre-existing tflint failures in `infra/aws/main.tf`/`outputs.tf` (unused `time`/`tls`/`cloudinit` providers, 3 undocumented outputs, one `//` comment) — the pre-commit hook lints the whole file, so these blocked committing at all once I touched the same file.

## Tests
`terraform fmt -check`, `terraform validate`, `tflint` — all pass, for the module standalone and for `infra/aws/` with it wired in. Pre-commit hooks pass on the commit (tfsec included). Can't run `terraform plan`/`apply` — no AWS credentials in this environment, so the IAM role and trust policy are unverified against a live account.

## Judgment calls for review
- `manage_namespace = false` choice (avoiding dual ownership with ArgoCD) — worth a second look given AGENTS.md's GitOps-source-of-truth principle.
- Placeholder ARN annotation approach for `serviceaccount.yaml` — open to a better GitOps-native substitution mechanism if one exists in this repo that I missed.
- `iam_policy_arns = []` for tracer-bullet — no AWS API access requirements were specified anywhere I could find; leaving empty rather than guessing permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)