### PR TITLE
feat(dora-metrics): deploy DORA metrics exporter via ArgoCD

### DIFF
--- a/.github/workflows/dora-metrics-ci.yml
+++ b/.github/workflows/dora-metrics-ci.yml
@@ -1,0 +1,192 @@
+name: DORA Metrics CI/CD
+
+# DORA Metrics exporter — end-to-end pipeline:
+# 1. Lint + test the service
+# 2. Build Docker image
+# 3. Push to GHCR (main branch only)
+# 4. Update K8s manifest image tag (GitOps commit)
+#
+# ArgoCD auto-syncs the updated manifest to the cluster.
+# Mirrors tracer-bullet-ci.yml's structure.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "services/dora-metrics/**"
+      - "platform/apps/dora-metrics/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "services/dora-metrics/**"
+      - "platform/apps/dora-metrics/**"
+
+permissions:
+  contents: write
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/paruff/dora-metrics
+  SERVICE_DIR: services/dora-metrics
+  MANIFEST_DIR: platform/apps/dora-metrics
+
+jobs:
+  # ==========================================================================
+  # Job 1: Lint + Test
+  # ==========================================================================
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: DORA job start
+        run: |
+          echo "job-start:$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "sha:${{ github.sha }}"
+          echo "workflow:${{ github.workflow }}"
+          echo "job:${{ github.job }}"
+
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: "${{ env.SERVICE_DIR }}/requirements*.txt"
+
+      - name: Install dependencies
+        working-directory: ${{ env.SERVICE_DIR }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Lint
+        working-directory: ${{ env.SERVICE_DIR }}
+        run: |
+          ruff check .
+          ruff format --check --diff .
+
+      - name: Test
+        working-directory: ${{ env.SERVICE_DIR }}
+        run: pytest tests/
+
+      - name: DORA job finish
+        if: always()
+        run: echo "job-finish:$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  # ==========================================================================
+  # Job 2: Build + Push Docker Image (main only)
+  # ==========================================================================
+  build:
+    name: Build & Push
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: test
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    outputs:
+      image_tag: ${{ steps.meta.outputs.version }}
+    steps:
+      - name: DORA job start
+        run: |
+          echo "job-start:$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "sha:${{ github.sha }}"
+          echo "workflow:${{ github.workflow }}"
+          echo "job:${{ github.job }}"
+
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: ${{ env.SERVICE_DIR }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Install Trivy
+        run: |
+          TRIVY_VERSION=v0.73.0
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${TRIVY_VERSION}
+
+      - name: Trivy scan
+        run: |
+          trivy image \
+            --exit-code 1 \
+            --severity CRITICAL,HIGH \
+            --no-progress \
+            ${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+
+      - name: DORA job finish
+        if: always()
+        run: echo "job-finish:$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  # ==========================================================================
+  # Job 3: Update GitOps manifest (main only)
+  # ==========================================================================
+  update-gitops:
+    name: Update GitOps
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: build
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - name: DORA job start
+        run: |
+          echo "job-start:$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "sha:${{ github.sha }}"
+          echo "workflow:${{ github.workflow }}"
+          echo "job:${{ github.job }}"
+
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update image tag in manifest
+        run: |
+          NEW_TAG="${{ needs.build.outputs.image_tag }}"
+          echo "Updating image tag to: ${NEW_TAG}"
+          sed -i "s|image: ${IMAGE_NAME}:.*|image: ${IMAGE_NAME}:${NEW_TAG}|g" \
+            ${MANIFEST_DIR}/deployment.yaml
+          sed -i "s|app.kubernetes.io/version:.*|app.kubernetes.io/version: ${NEW_TAG}|g" \
+            ${MANIFEST_DIR}/deployment.yaml
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add ${MANIFEST_DIR}/deployment.yaml
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore(dora-metrics): update image tag to ${NEW_TAG}"
+            git push
+          fi
+
+      - name: DORA job finish
+        if: always()
+        run: echo "job-finish:$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/platform/apps/dora-metrics-application.yaml
+++ b/platform/apps/dora-metrics-application.yaml
@@ -1,0 +1,64 @@
+# Copyright (c) 2025  Philip Ruff
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+# OR OTHER DEALINGS IN THE SOFTWARE.
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dora-metrics
+  namespace: argocd
+  labels:
+    app: dora-metrics
+    app.kubernetes.io/name: dora-metrics
+    app.kubernetes.io/part-of: fawkes
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/managed-by: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/paruff/fawkes.git
+    targetRevision: HEAD
+    path: platform/apps/dora-metrics
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: fawkes
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=true
+      - PruneLast=true
+      - PrunePropagationPolicy=foreground
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/replicas

--- a/platform/apps/dora-metrics/deployment.yaml
+++ b/platform/apps/dora-metrics/deployment.yaml
@@ -1,0 +1,116 @@
+# Copyright (c) 2025  Philip Ruff
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+# OR OTHER DEALINGS IN THE SOFTWARE.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dora-metrics
+  namespace: fawkes
+  labels:
+    app: dora-metrics
+    version: latest
+    app.kubernetes.io/name: dora-metrics
+    app.kubernetes.io/version: latest
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/part-of: fawkes
+    app.kubernetes.io/managed-by: argocd
+    team: platform-team
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dora-metrics
+  template:
+    metadata:
+      labels:
+        app: dora-metrics
+        app.kubernetes.io/name: dora-metrics
+        app.kubernetes.io/version: latest
+        app.kubernetes.io/component: observability
+        app.kubernetes.io/part-of: fawkes
+        team: platform-team
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8000"
+        prometheus.io/path: "/metrics"
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: dora-metrics
+          image: ghcr.io/paruff/dora-metrics:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          env:
+            - name: ARGOCD_BASE_URL
+              value: "http://argocd-server.argocd.svc:80"
+            - name: GITHUB_REPO
+              value: "paruff/fawkes"
+            - name: SCRAPE_INTERVAL
+              value: "60"
+            - name: ARGOCD_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: dora-metrics-argocd-token
+                  key: token
+                  optional: true
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: dora-metrics-github-token
+                  key: token
+                  optional: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault

--- a/platform/apps/dora-metrics/kustomization.yaml
+++ b/platform/apps/dora-metrics/kustomization.yaml
@@ -1,0 +1,33 @@
+# Copyright (c) 2025  Philip Ruff
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+# OR OTHER DEALINGS IN THE SOFTWARE.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: fawkes
+
+resources:
+  - secrets.yaml
+  - deployment.yaml
+  - service.yaml
+
+commonLabels:
+  app.kubernetes.io/part-of: fawkes
+  app.kubernetes.io/managed-by: argocd

--- a/platform/apps/dora-metrics/secrets.yaml
+++ b/platform/apps/dora-metrics/secrets.yaml
@@ -1,0 +1,59 @@
+# Copyright (c) 2025  Philip Ruff
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+# OR OTHER DEALINGS IN THE SOFTWARE.
+
+# ============================================================================
+# FILE: platform/apps/dora-metrics/secrets.yaml
+# PURPOSE: Placeholder secrets for the DORA Metrics exporter
+# NOTE: These are placeholder values. Real secrets should be managed via
+#       External Secrets Operator or sealed-secrets in production.
+#
+# ⚠️  SECURITY WARNING: These default values are INSECURE and must be replaced
+#     before deploying to any environment accessible outside localhost.
+#     Both tokens are optional — the service runs (unauthenticated against
+#     GitHub, no-auth against in-cluster ArgoCD) without them, just at
+#     lower GitHub API rate limits.
+# ============================================================================
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dora-metrics-github-token
+  namespace: fawkes
+  labels:
+    app: dora-metrics
+    component: observability
+    environment: dev
+    team: platform
+type: Opaque
+stringData:
+  token: "CHANGE_ME_github_token_here"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dora-metrics-argocd-token
+  namespace: fawkes
+  labels:
+    app: dora-metrics
+    component: observability
+    environment: dev
+    team: platform
+type: Opaque
+stringData:
+  token: "CHANGE_ME_argocd_token_here"

--- a/platform/apps/dora-metrics/service.yaml
+++ b/platform/apps/dora-metrics/service.yaml
@@ -1,0 +1,40 @@
+# Copyright (c) 2025  Philip Ruff
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+# OR OTHER DEALINGS IN THE SOFTWARE.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: dora-metrics
+  namespace: fawkes
+  labels:
+    app: dora-metrics
+    app.kubernetes.io/name: dora-metrics
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/part-of: fawkes
+    app.kubernetes.io/managed-by: argocd
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: dora-metrics

--- a/services/dora-metrics/pytest.ini
+++ b/services/dora-metrics/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/services/dora-metrics/requirements-dev.txt
+++ b/services/dora-metrics/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest==9.1.1
+pytest-cov==5.0.0
+ruff==0.15.20

--- a/services/dora-metrics/tests/test_main.py
+++ b/services/dora-metrics/tests/test_main.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2025  Philip Ruff
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+# OR OTHER DEALINGS IN THE SOFTWARE.
+
+from app.main import app
+from fastapi.testclient import TestClient
+
+# Instantiated without `with`, so the startup event (background scraper
+# hitting ArgoCD/GitHub over the network) never runs.
+client = TestClient(app)
+
+
+def test_health():
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_ready():
+    resp = client.get("/ready")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ready"}
+
+
+def test_metrics_exposes_dora_gauge_names():
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "dora_deployments_total" in body
+    assert "dora_lead_time_seconds" in body


### PR DESCRIPTION
## What
Part of MVP P0 issue #1572. Deploys `services/dora-metrics` — the FastAPI service that already implements the DORA Prometheus gauges (`dora_deployments_total`, `dora_lead_time_seconds`, etc.) that `platform/apps/grafana/dashboards/dora-metrics-dashboard.json` already queries — but was never actually running anywhere. New ArgoCD `Application`, K8s manifests, and a CI pipeline to build/push its image (none existed).

## Layer(s) touched
`.github/workflows/` (new file), `platform/apps/` (new dir + Application), `services/dora-metrics/` (tests + one lint-driven CI choice). Flagging `.github/workflows/dora-metrics-ci.yml` per AGENTS.md's "Must Ask Before: Modifying `.github/workflows/`" — it's a new file, mirrors `tracer-bullet-ci.yml`'s structure.

## Real gap found, not just "unverified"
Grafana panels for DORA metrics have likely always shown "no data" — the metric-emitting service existed in source but was never deployed. Separately, **DevLake** (the system ADR-016 actually chose) is deployed and does its own thing; these are two parallel, only-one-of-which-is-wired DORA metrics paths. I deployed `services/dora-metrics` per your explicit choice ("Deploy services/dora-metrics — smallest diff, makes the existing dashboard queries work as-is"), not the DevLake rework option — worth a human decision at some point on whether to consolidate onto one path long-term.

## Scope adjustment from the original ask
The original plan (my phrasing, before I'd read the source) was "wire tracer-bullet-ci.yml to call it on deploy." Having read `services/dora-metrics/app/main.py`, that doesn't fit: this service **pulls** ArgoCD + GitHub Actions data on its own 60s background loop — there's no push/webhook contract to wire into, and it has no public ingress a GitHub-hosted runner could reach anyway. The self-scrape already satisfies the actual requirement (metrics eventually populate); I didn't bolt on an unreachable CI call just to match the literal original phrasing.

## Tests
- `kustomize build platform/apps/dora-metrics/` + `kubeconform -strict` — 4/4 resources valid
- `yamllint` clean on all new YAML (same pre-existing warning pattern as `tracer-bullet-ci.yml`, not new)
- `pytest` — 3/3 pass (new `tests/test_main.py`, this service had zero tests before)
- `ruff check` / `ruff format --check` clean
- Pre-commit hooks pass on the commit, including "Validate ArgoCD applications"
- **Not verified**: actual ArgoCD sync, live Grafana query results — no cluster access in this environment

## Judgment calls for review
- Placeholder `GITHUB_TOKEN`/`ARGOCD_TOKEN` Secrets (`CHANGE_ME_*`) following `platform/apps/feedback-service/secrets.yaml`'s existing convention exactly — both `optional: true`, service tolerates missing tokens at reduced GitHub API rate limits.
- New CI lint step uses `ruff format --check` instead of copying `tracer-bullet-ci.yml`'s `black --check` — this repo's actual pre-commit hook is ruff-format, and it disagrees with black on one pre-existing line in `main.py`. Using what's actually enforced avoids a false CI failure; didn't touch the pre-existing line itself.
- Test coverage is intentionally partial — `/health`, `/ready`, `/metrics` only, not the async ArgoCD/GitHub scrape functions (would need substantial httpx mocking). Flagging as a real gap, not claiming otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)